### PR TITLE
fixes multiple file being required from one dir

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,9 @@ argv._.forEach(function(file_or_dir) {
         return path.join(cwd, file_or_dir, file);
     });
 
-    files.forEach(bundle.require.bind(bundle, { entry: true }));
+    files.forEach(function (file) { 
+      bundle.require(file, { entry: true });
+    });
 });
 
 // options which will be passed to `mocha.setup`


### PR DESCRIPTION
- previously was binding function, but file param needs to be before opts - { entry: true }
- this caused an error in browser-resolve which treated { entry: true } as a string
