### PR TITLE
logging bundle error server side and sending a 500

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,6 +108,10 @@ app.get('/', function(req, res) {
 app.get('/build.js', function(req, res) {
     res.contentType('application/javascript');
     bundle.bundle({ insertGlobals: true }, function(err, src) {
+        if (err) { 
+          console.error(err);
+          return res.send(500);
+        }
         res.end(src);
     });
 });


### PR DESCRIPTION
In my case that logs something along the lines of:

```
server listening: http://localhost:3000
[Error: Cannot find module 'jquery']
[Error: Cannot find module 'core']
```

which definitely helps to find my problem.
Previously it just sent `undefined` as the bundle.
