### PR TITLE
FIX: Browser version parsing when only 'latest' specified

### DIFF
--- a/lib/browsers.js
+++ b/lib/browsers.js
@@ -65,7 +65,7 @@ function expand_browsers(request, cb) {
             function process_version_str(version) {
                 version = String(version);
                 if (version === 'latest') {
-                    return [avail.slice(-1)]
+                    return avail.slice(-1);
                 }
 
                 // split version string on two dots to see if range was specified


### PR DESCRIPTION
In .zuul.yml if you specify just:

```
- name: iphone
  version: latest
```

It will accidentally return something like this when running zuul:

```
zuul:sauce add undefined undefined undefined +0ms
- testing: undefined @ undefined:
```

Correct it so it correctly run the test:

```
zuul:sauce add iphone 6.1 Mac 10.8 +0ms
- testing: iphone @ iOS: 6.1
```
