### PR TITLE
FIX: Use webdriver-specific endpoint to query for supported browsers

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -14,7 +14,7 @@ var https = require('https');
 module.exports = function(cb) {
     var info_opt = {
         host: 'saucelabs.com',
-        path: '/rest/v1.1/info/scout?os_product_names=true'
+        path: '/rest/v1/info/browsers/webdriver'
     };
 
     https.get(info_opt, function(res) {
@@ -38,20 +38,20 @@ module.exports = function(cb) {
 function format(obj) {
     var browsers = {};
     obj.forEach(function(info) {
-        var name = info.name;
+        var name = info.api_name;
 
         var browser = browsers[name] = browsers[name] || [];
         browser.push({
             name: name,
             version: info.short_version,
             platform: info.os,
-            platform_display: info.os_display
         });
     });
 
     // common mappings for some of us senile folks
-    browsers.ie = browsers.iexplore;
-    browsers.chrome = browsers.googlechrome;
+    browsers.iexplore = browsers['internet explorer'];
+    browsers.ie = browsers['internet explorer'];
+    browsers.googlechrome = browsers.chrome;
 
     return browsers;
 }

--- a/lib/browsers.js
+++ b/lib/browsers.js
@@ -24,8 +24,7 @@ function expand_browsers(request, cb) {
 
             if (req.platform) {
                 avail = avail.filter(function(browser) {
-                    return req.platform.toLowerCase() === browser.platform.toLowerCase() ||
-                        req.platform.toLowerCase() === browser.platform_display.toLowerCase()
+                    return req.platform.toLowerCase() === browser.platform.toLowerCase()
                 });
             }
 

--- a/lib/zuul.js
+++ b/lib/zuul.js
@@ -104,7 +104,7 @@ module.exports = function(config) {
             var by_os = {};
             browsers.forEach(function(browser) {
                 cloud.browser(browser.name, browser.version, browser.platform);
-                var key = browser.name + ' @ ' + browser.platform_display;
+                var key = browser.name + ' @ ' + browser.platform;
                 (by_os[key] = by_os[key] || []).push(browser.version);
             });
 


### PR DESCRIPTION
The previous endpoint (scout) will sometimes erroneously report supported browsers that weren't actually supported.
