### PR TITLE
adding clipboard support

### DIFF
--- a/frameworks/index.html
+++ b/frameworks/index.html
@@ -16,6 +16,7 @@
   <script src="{{this}}"></script>
   {{/each}}
 
+  <script src="/__zuul/ZeroClipboard.js"></script>
   <script src="/__zuul/framework.js"></script>
   <script src="/__zuul/client.js"></script>
 </body>

--- a/frameworks/zuul.css
+++ b/frameworks/zuul.css
@@ -61,8 +61,27 @@ html, body {
 }
 
 .trace-anchor a {
-  color: white;
-  line-height: 5px;
-  margin: 0;
-  padding: 0;
+    color: white;
+    line-height: 5px;
+    margin: 0;
+    padding: 0;
 }
+
+.trace-anchor button {
+    cursor           : pointer;
+    width            : 50px;
+    text-align       : center;
+    border           : 1px solid darkred;
+    border-radius    : 3px;
+    background-color : #ccc;
+    padding          : 5px;
+    margin-right     : 3px;
+    margin-top       : -30px;
+}
+
+.trace-anchor textarea {
+  display: none;
+} 
+
+.trace-anchor button.zeroclipboard-is-hover { background-color:#eee; }
+.trace-anchor button.zeroclipboard-is-active { background-color:#aaa; }

--- a/frameworks/zuul.js
+++ b/frameworks/zuul.js
@@ -249,13 +249,12 @@ ZuulReporter.prototype._renderError = function (stack, frames, message, error) {
     if (mapper && frames.length) {
         var mapped = mapper.map(frames);
         str = trace_anchors(mapped, self._source_map);
-        // TODO:(thlorenz) pass opts if we wanna configure how traces are shown
-        //str = plainString(mapped);
     }
 
     var pre = document.createElement('pre');
     pre.innerHTML = str ? str : (stack || message || error.toString());
     self._current_container.appendChild(pre);
+    trace_anchors.init_clipboard();
 };
 
 function plainString (mapped) {

--- a/lib/control-app.js
+++ b/lib/control-app.js
@@ -6,6 +6,9 @@ var convert = require('convert-source-map');
 var expstate = require('express-state');
 var browserify = require('browserify');
 
+var zeroclipboard_js = require.resolve('zeroclipboard');
+var zeroclipboard_swf = zeroclipboard_js.slice(0, -3) + '.swf';
+
 function create_bundle(files) {
     var bundler = browserify();
 
@@ -78,6 +81,16 @@ module.exports = function(config) {
 
     app.get('/__zuul', function(req, res) {
         res.render('index');
+    });
+
+    app.get('/__zuul/ZeroClipboard.js', function (req, res) {
+        res.setHeader('Content-Type', 'application/javascript');
+        res.sendfile(zeroclipboard_js);
+    });
+
+    app.get('/__zuul/ZeroClipboard.swf', function (req, res) {
+        res.setHeader('Content-Type', 'application/x-shockwave-flash');
+        res.sendfile(zeroclipboard_swf);
     });
 
     var map = undefined;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "superagent": "0.15.7",
     "stacktrace-js": "defunctzombie/stacktrace.js#07e7b95",
     "char-split": "0.2.0",
-    "highlight.js": "7.5.0"
+    "highlight.js": "7.5.0",
+    "zeroclipboard": "1.3.0-beta.1"
   },
   "devDependencies": {
     "mocha": "~1.16.2",


### PR DESCRIPTION
- first stack trace can be clipped via Copy button
- adding zeroclipboard dependency
- adding routes to load zeroclipboard js and swf files which are
  resolved from node_modules
- adding script tag to load zeroclipboard (that's the only way it works)
- adding related styles
