### PR TITLE
Retrying to instantiate a browser when getting error status 13 from wd

### DIFF
--- a/lib/SauceBrowser.js
+++ b/lib/SauceBrowser.js
@@ -10,6 +10,7 @@ function SauceBrowser(conf, opt) {
     };
 
     var self = this;
+    self._retries = 0;
     self._conf = conf;
     self._opt = opt;
     self._opt.tunnel = true;
@@ -122,9 +123,11 @@ SauceBrowser.prototype.shutdown = function(err) {
     if (err) {
         // if the environment can't be set up, we should retry since Zuul will
         // never try to initialize environments that don't exist
-        if (~err.message.indexOf('Error response status: 13')
-                || ~err.message.indexOf('The environment you requested was unavailable')
-                || (err.message == 'Not JSON response' && ~err.data.indexOf('not in progress'))) {
+        if (self._retries < 3
+                && (~err.message.indexOf('Error response status: 13')
+                    || ~err.message.indexOf('The environment you requested was unavailable')
+                    || (err.message == 'Not JSON response' && ~err.data.indexOf('not in progress')))) {
+            self._retries++;
             return self.start();
         }
         self.emit('error', err);


### PR DESCRIPTION
Sometimes when trying to instantiate a completely legitimate platform and browser combo you still get an error from saucelabs that says that the environment can't be set up for some reason. Zuul verifies that each tried setup is available before even trying to instantiate such a browser, so we can safely catch that error and try to reinstantiate the browser. Not simply quitting on it should save us some trouble with e.g. travis builds.

The PR checks for two kinds of errors, because essentially the same error can be thrown in two places. One of them is here: https://github.com/admc/wd/blob/master/lib/webdriver.js#L127 and the other is here https://github.com/admc/wd/blob/master/lib/callbacks.js#L26. 
