### PR TITLE
adding option to turn off colors in the console

### DIFF
--- a/bin/zuul
+++ b/bin/zuul
@@ -31,6 +31,26 @@ var config = {
     prj_dir: process.cwd()
 };
 
+if(!process.stdout.isTTY){
+    colors.setTheme({
+        bold: 'stripColors',
+        italic: 'stripColors',
+        underline: 'stripColors',
+        inverse: 'stripColors',
+        yellow: 'stripColors',
+        cyan: 'stripColors',
+        white: 'stripColors',
+        magenta: 'stripColors',
+        green: 'stripColors',
+        red: 'stripColors',
+        grey: 'stripColors',
+        blue: 'stripColors',
+        rainbow: 'stripColors',
+        zebra: 'stripColors',
+        random: 'stripColors'
+    });
+}
+
 if (config.files.length === 0) {
     console.error('at least one `js` test file must be specified');
     return process.exit(1);


### PR DESCRIPTION
It would be awesome to turn off colored output in some environments.

We are stuck using Jenkins at work and it's probably incorrectly configured, but I don't have access to fix it's configuration.

The problem is this is what the logs look like:

```
Initialized cnt-feature-modal module, please edit ./client/init.js and ./client/cnt-feature-modal.js to match your feature
passed: [32mcan insert a new image[39m
starting [37mcan fetch next slideshow[39m
Initialized cnt-feature-modal module, please edit ./client/init.js and ./client/cnt-feature-modal.js to match your feature
passed: [32mcan fetch next slideshow[39m
starting [37mstitching new slide from next gallery[39m
Initialized cnt-feature-modal module, please edit ./client/init.js and ./client/cnt-feature-modal.js to match your feature
passed: [32mstitching new slide from next gallery[39m
starting [37mfind index of a slide in the DOM[39m
Initialized cnt-feature-modal module, please edit ./client/init.js and ./client/cnt-feature-modal.js to match your feature
passed: [32mfind index of a slide in the DOM[39m
[31mError: timeout of 2000ms exceeded[39m
[90m    {anonymous}() http://localhost:45091/__zuul/client.js:1075[39m
[90m    {anonymous}() http://localhost:45091/__zuul/client.js:688[39m
[90m    {anonymous}() http://localhost:45091/__zuul/framework.js:583[39m
[90m    {anonymous}() http://localhost:45091/__zuul/framework.js:4539[39m
[90m    {anonymous}() http://localhost:45091/__zuul/framework.js:4795[39m
[90m    done http://localhost:45091/__zuul/framework.js:4295[39m
[90m    {anonymous}() http://localhost:45091/__zuul/framework.js:4275[39m
```

Yeah, that's super ugly right?

I couldn't think of a good way to test this -- open to suggestions and happy to implement if necessary.
