### PR TITLE
Adds the ability to specify Firefox extensions to load

### DIFF
--- a/lib/SauceBrowser.js
+++ b/lib/SauceBrowser.js
@@ -54,14 +54,18 @@ SauceBrowser.prototype.start = function() {
 
         if (conf.firefox_profile) {
             var fp = new FirefoxProfile();
+            var extensions = conf.firefox_profile.extensions;
             for (var preference in conf.firefox_profile) {
-                fp.setPreference(
-                    preference,
-                    conf.firefox_profile[preference]);
+                if (preference !== 'extensions') {
+                    fp.setPreference(preference, conf.firefox_profile[preference]);
+                }
             }
-            fp.encoded(function(zippedProfile) {
-                init_conf.firefox_profile = zippedProfile;
-                init();
+            extensions = extensions ? extensions : [];
+            fp.addExtensions(extensions, function () {
+                fp.encoded(function(zippedProfile) {
+                    init_conf.firefox_profile = zippedProfile;
+                    init();
+                });
             });
         } else {
             init();


### PR DESCRIPTION
Extensions are specified in the firefox_profile field in .zuul.yml by providing a list of paths to either XPI files or the unpacked extensions. This is useful for testing your own browser extensions or for testing your pages work correctly in the presence of certain browser extensions, and probably other things I haven't thought of.

Example of using an extension:

```
browsers:
    - name: firefox
      firefox_profile:
          extensions:
              - ./path/to/extension.xpi
```
