### PR TITLE
Fixes 'latest' keyword not always returning highest available version

### DIFF
--- a/lib/flatten_browser.js
+++ b/lib/flatten_browser.js
@@ -41,6 +41,15 @@ function flatten(request, all_browsers, cb) {
 
         avail = avail.filter(Boolean);
 
+        // sort version entries putting 'beta' last always
+        avail = avail.sort(function(a, b) {
+            if (a.version === 'beta') {
+                return 1;
+            } else {
+                return (parseInt(a.version, 10) - parseInt(b.version, 10));
+            }
+        });
+
         // version is an array, we should add each item from array
         if (Array.isArray(req.version)) {
             return req.version.forEach(function(version) {
@@ -59,7 +68,9 @@ function flatten(request, all_browsers, cb) {
         function process_version_str(version) {
             version = String(version);
             if (version === 'latest') {
-                return avail.slice(-1).map(addProfile);
+                return avail.filter(function (el) {
+                    return el.version !== 'beta';
+                }).slice(-1).map(addProfile);
             }
             else if (version === 'oldest') {
                 return avail.slice(0, 1).map(addProfile);


### PR DESCRIPTION
The list of available versions is not always ordered, meaning `latest` just taking the last element of the list doesn't result in the truly latest browser in all cases.

You can see this behavior in master currently with the following `.zuul.yml` browsers field:

```
browsers:
    - name: chrome
      platform: Windows 2012 R2
      version: latest
```

The result should be a test run in Chrome 35 on Windows 2012 R2, but instead a test is run in Chrome 31.

I added a guarantee that the `beta` version won't get selected when a user specifies `latest`, since that seemed like more intuitive behavior to me and because with the sorting strategy used `beta` would now always be the value of `latest` for Chrome.
