### PR TITLE
User configurable localtunnel server URL

### DIFF
--- a/bin/zuul
+++ b/bin/zuul
@@ -20,6 +20,7 @@ program
 .option('--local [port]', 'port for manual testing in a local browser')
 .option('--tunnel', 'establish a tunnel for outside acceess. only used when --local is specified')
 .option('--phantom', 'run tests in phantomjs. PhantomJS must be installed separately.')
+.option('--tunnel-host <host url>', 'specify a localtunnel server to use for forwarding')
 .parse(process.argv);
 
 var config = {
@@ -28,7 +29,8 @@ var config = {
     ui: program.ui,
     tunnel: program.tunnel,
     phantom: program.phantom,
-    prj_dir: process.cwd()
+    prj_dir: process.cwd(),
+    tunnel_host: program.tunnelHost
 };
 
 if(!process.stdout.isTTY){
@@ -67,6 +69,7 @@ var home_config = path.join(osenv.home(), '.zuulrc');
 if (fs.existsSync(home_config)) {
     var zuulrc = yaml.parse(fs.readFileSync(home_config, 'utf-8'));
     config = xtend(zuulrc, config);
+    config.tunnel_host = config.tunnel_host || zuulrc.tunnel_host;
 }
 
 var sauce_username = process.env.SAUCE_USERNAME;

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -58,7 +58,7 @@ function setup_test_instance(opt, cb) {
                 return cb(null, 'http://localhost:' + app_port + '/__zuul');
             }
 
-            tunnel(app_port, function(err, lt) {
+            tunnel(app_port, { host: config.tunnel_host || 'http://localtunnel.me' }, function(err, lt) {
                 if (err) {
                     return cb(err);
                 }


### PR DESCRIPTION
Adds a new command line option `--tunnel-host` with a mandatory argument which should be a URL at which a localtunnel server may be found. If the option is set, that localtunnel server is used to broker the connection to Sauce Labs and when exposing a local test with `--tunnel`.

The tunnel host can also be set in `~/.zuulrc` using the `tunnel_host` field: eg. `tunnel_host: http://my.own.localtunnel.server`.

Example:

```
$ zuul --ui qunit --local --tunnel -- test/*.js 
open the following url in a browser:
https://bhcaltyqvu.localtunnel.me/__zuul

$ zuul --ui qunit --local --tunnel --tunnel-host http://privatetunnel.com -- test/*.js 
open the following url in a browser:
https://bmxjnyuhmk.privatetunnel.com/__zuul
```
