### PR TITLE
Fix bug parsing chrome version string "30..latest"

### DIFF
--- a/lib/flatten_browser.js
+++ b/lib/flatten_browser.js
@@ -68,9 +68,7 @@ function flatten(request, all_browsers, cb) {
         function process_version_str(version) {
             version = String(version);
             if (version === 'latest') {
-                return avail.filter(function (el) {
-                    return el.version !== 'beta';
-                }).slice(-1).map(addProfile);
+                return getNumericVersions(avail).slice(-1).map(addProfile);
             }
             else if (version === 'oldest') {
                 return avail.slice(0, 1).map(addProfile);
@@ -89,7 +87,7 @@ function flatten(request, all_browsers, cb) {
                 }
 
                 if (end === 'latest') {
-                    end = avail.slice(-1)[0].version;
+                    end = getNumericVersions(avail).slice(-1)[0].version;
                 }
 
                 start = start - 0;
@@ -107,6 +105,12 @@ function flatten(request, all_browsers, cb) {
             return avail.filter(function(browser) {
                 return browser.version == version;
             }).map(addProfile);
+
+            function getNumericVersions(browsers) {
+                return browsers.filter(function (el) {
+                    return Number(el.version) >= 0;
+                })
+            }
 
             function addProfile(browser) {
                 if (req.firefox_profile) {


### PR DESCRIPTION
This fixes a bug where parsing the following browser field in .zuul.yml
config fails:

```
browsers:
  - name: chrome
    version: 35..latest
```

Casting ‘beta’ to a number results in the end version being set to NaN.
