### PR TITLE
Allow using a custom port in phantom.js

### DIFF
--- a/bin/zuul
+++ b/bin/zuul
@@ -19,7 +19,7 @@ program
 .option('--ui <testing ui>', 'ui for tests (mocha-bdd, mocha-tdd, qunit, tape)')
 .option('--local [port]', 'port for manual testing in a local browser')
 .option('--tunnel', 'establish a tunnel for outside acceess. only used when --local is specified')
-.option('--phantom', 'run tests in phantomjs. PhantomJS must be installed separately.')
+.option('--phantom [port]', 'run tests in phantomjs. PhantomJS must be installed separately.')
 .option('--tunnel-host <host url>', 'specify a localtunnel server to use for forwarding')
 .parse(process.argv);
 

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -38,6 +38,10 @@ function setup_test_instance(opt, cb) {
             bouncer_port = config.local;
         }
 
+        if (config.phantom && parseInt(config.phantom)) {
+            bouncer_port = config.phantom;
+        }
+
         bouncer = bouncy(function (req, res, bounce) {
             var url = req.url.split('?')[0];
             if (!support_port || url.split('/')[1] === '__zuul') {


### PR DESCRIPTION
HI, I'd like to be able to specify the port when running with the `--phantom` option.

I've used the same syntax than in the `--local` option. 

Thank you very much for this very useful tool
