### PR TITLE
Allow upgrade requests to bounce through unchanged

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -46,7 +46,7 @@ function setup_test_instance(opt, cb) {
             }
 
             var opts = {};
-            if (req.headers.connection !== 'Upgrade') {
+            if (req.headers.connection.toLowerCase().indexOf('upgrade') === -1) {
                 opts.headers = { connection: 'close' };
             }
             bounce(support_port, opts);


### PR DESCRIPTION
This fixes websocket requests that proxy through zuul to the support
server
