### PR TITLE
close defunctzombie/zuul#103

### DIFF
--- a/lib/user-server.js
+++ b/lib/user-server.js
@@ -5,11 +5,29 @@ var copy = require('shallow-copy');
 var parse_cmd = require('shell-quote').parse;
 var debug = require('debug')('zuul:user-server');
 
-module.exports = function(cmd, callback) {
-    debug('user server: %s', cmd);
+module.exports = function(server, callback) {
+    debug('user server: %s', server);
 
-    // TODO(shtylman) is this right?
-    var dir = process.cwd();
+    var cmd;
+    var cwd;
+    if (server !== null && server.cmd) {
+        // expect the following format in .zuul.yml
+        // server:
+        //   cmd: ./test/support/server.js
+        //   cwd: ./anotherapp
+        cmd = server.cmd;
+        cwd = server.cwd;
+    }
+    else {
+        // expect the following format in .zuul.yml
+        // server: ./test/support/server.js
+        cmd = server;
+    }
+
+    if (!cwd) {
+        // TODO(shtylman) is this right?
+        cwd = process.cwd();
+    }
 
     if (!Array.isArray(cmd)) {
         cmd = parse_cmd(cmd);
@@ -26,7 +44,7 @@ module.exports = function(cmd, callback) {
 
         debug('user server port %d', port);
 
-        var ps = spawn(cmd[0], cmd.slice(1), { cwd: dir, env: env });
+        var ps = spawn(cmd[0], cmd.slice(1), { cwd: cwd, env: env });
         ps.stdout.pipe(process.stdout);
         ps.stderr.pipe(process.stderr);
 


### PR DESCRIPTION
It was impossible to run a testing support server from another directory
because of the following code in `lib/user-server.js`

```
var dir = process.cwd();
```

Therefore, I needed to add support to the following format with dir option:

```
server:
  ./test/support/server.js:
    dir: ../anotherapp
```

https://github.com/defunctzombie/zuul/issues/103
