### PR TITLE
Added concurrency option

### DIFF
--- a/bin/zuul
+++ b/bin/zuul
@@ -28,6 +28,7 @@ program
 .option('--browser-name <browser name>', 'specficy the browser name to test an individual browser')
 .option('--browser-version <browser version>', 'specficy the browser version to test an individual browser')
 .option('--browser-platform <browser platform>', 'specficy the browser platform to test an individual browser')
+.option('--concurrency <n>', 'specify the number of concurrent browsers to test')
 .option('--open', 'open a browser automatically. only used when --local is specified')
 .parse(process.argv);
 
@@ -41,6 +42,7 @@ var config = {
     tunnel_host: program.tunnelHost,
     sauce_connect: program.sauceConnect,
     server: program.server,
+    concurrency: program.concurrency,
     open: program.open
 };
 


### PR DESCRIPTION
This looks like an option that was originally planned, given Zuul's constructor, so thought it would make for a good addition. I seem to have a bit more luck with WD when concurrency is 1.
