### PR TITLE
Complete defunctzombie/zuul#74 Enable use of $ZUUL_PORT in server

### DIFF
--- a/lib/user-server.js
+++ b/lib/user-server.js
@@ -29,17 +29,17 @@ module.exports = function(server, callback) {
         cwd = process.cwd();
     }
 
-    if (!Array.isArray(cmd)) {
-        cmd = parse_cmd(cmd);
-    }
-
-    if (/\.js$/.test(cmd[0])) {
-        cmd.unshift(process.execPath);
-    }
-
     var env = copy(process.env);
 
     get_open_port(function(port) {
+        if (!Array.isArray(cmd)) {
+            cmd = parse_cmd(cmd, { ZUUL_PORT: port });
+        }
+
+        if (/\.js$/.test(cmd[0])) {
+            cmd.unshift(process.execPath);
+        }
+
         env.ZUUL_PORT = port;
 
         debug('user server port %d', port);


### PR DESCRIPTION
In reference to https://github.com/defunctzombie/zuul/issues/74. Some example possible servers:

``` yaml
server: "python -m SimpleHTTPServer $ZUUL_PORT"
server: "http-server -p $ZUUL_PORT"
# etc
```
