### PR TITLE
Removed redundant semicolons

### DIFF
--- a/lib/PhantomBrowser.js
+++ b/lib/PhantomBrowser.js
@@ -9,7 +9,7 @@ var setup_test_instance = require('./setup');
 function PhantomBrowser(opt) {
     if (!(this instanceof PhantomBrowser)) {
         return new PhantomBrowser(opt);
-    };
+    }
 
     var self = this;
     self._opt = opt;
@@ -17,7 +17,7 @@ function PhantomBrowser(opt) {
         passed: 0,
         failed: 0
     };
-};
+}
 
 PhantomBrowser.prototype.__proto__ = EventEmitter.prototype;
 

--- a/lib/zuul.js
+++ b/lib/zuul.js
@@ -31,7 +31,7 @@ function Zuul(config) {
     self._browsers = [];
 
     self._concurrency = config.concurrency || 3;
-};
+}
 
 Zuul.prototype.__proto__ = EventEmitter.prototype;
 


### PR DESCRIPTION
Small fixes, hope I'm not coming across as pedantic. Just noticed them while reading through the code, hoping to contribute a bit. :) Hopefully this is consistent with your style, as in other cases, you don't end FunctionDeclarations with semicolons. Feel free to close if uninterested.
