### PR TITLE
Clear wait_interval on restart

### DIFF
--- a/bin/zuul
+++ b/bin/zuul
@@ -202,6 +202,7 @@ scout_browser(function(err, all_browsers) {
 
     zuul.on('browser', function(browser) {
         var name = browser.toString();
+        var wait_interval;
 
         browser.once('init', function() {
             console.log('- queuing: %s'.grey, name);
@@ -209,10 +210,6 @@ scout_browser(function(err, all_browsers) {
 
         browser.once('start', function(reporter) {
             console.log('- starting: %s'.white, name);
-
-            var wait_interval = setInterval(function() {
-                console.log('- waiting: %s'.yellow, name);
-            }, 1000 * 30);
 
             var current_test = undefined;
             reporter.on('test', function(test) {
@@ -237,6 +234,13 @@ scout_browser(function(err, all_browsers) {
             reporter.once('done', function() {
                 clearInterval(wait_interval);
             });
+        });
+
+        browser.on('start', function() {
+            clearInterval(wait_interval);
+            wait_interval = setInterval(function() {
+                console.log('- waiting: %s'.yellow, name);
+            }, 1000 * 30);
         });
 
         browser.once('done', function(results) {


### PR DESCRIPTION
In response to the reply here https://github.com/defunctzombie/zuul/issues/97#issuecomment-65977739 and the issue highlighted in https://github.com/defunctzombie/zuul/issues/97#issuecomment-65977621. Clears the interval so that waiting statements aren't printed after a browser is restarted. It's an ugly solution, since I'm attaching the interval to the browser, but listening for the restart event with zuul. It might be nicer to eventually have `restart` emitted by the browser itself, rather than have zuul emit browsers through both `browser` and `restart`.
