### PR TITLE
ensure browser.quit finishes before finishing SauceBrowser.shutdown

### DIFF
--- a/lib/SauceBrowser.js
+++ b/lib/SauceBrowser.js
@@ -129,10 +129,6 @@ SauceBrowser.prototype.start = function() {
                             return;
                             // don't let this error fail us
                         }
-
-                        browser.quit(function(err) {
-                            // browser quit error doesn't matter
-                        });
                     });
 
                     reporter.removeAllListeners();
@@ -205,23 +201,30 @@ SauceBrowser.prototype.shutdown = function(err) {
     var self = this;
 
     self.stopped = true;
-    debug('shutdown');
 
+    finish_shutdown = function() {
+        debug('shutdown');
+        if (self.controller) {
+            self.controller.shutdown();
+        }
+        
+        if (err) {
+            self.emit('error', err);
+            return;
+        }
+        
+        self.emit('done', self.stats);
+        self.removeAllListeners();
+    }
+
+    // make sure the browser shuts down before continuing
     if (self.browser) {
-        self.browser.quit();
+        debug('quitting browser');
+        self.browser.quit(finish_shutdown);          
     }
-
-    if (self.controller) {
-        self.controller.shutdown();
+    else {
+        finish_shutdown();
     }
-
-    if (err) {
-        self.emit('error', err);
-        return;
-    }
-
-    self.emit('done', self.stats);
-    self.removeAllListeners();
 };
 
 module.exports = SauceBrowser;

--- a/lib/SauceBrowser.js
+++ b/lib/SauceBrowser.js
@@ -204,15 +204,16 @@ SauceBrowser.prototype.shutdown = function(err) {
 
     finish_shutdown = function() {
         debug('shutdown');
+
         if (self.controller) {
             self.controller.shutdown();
         }
-        
+
         if (err) {
             self.emit('error', err);
             return;
         }
-        
+
         self.emit('done', self.stats);
         self.removeAllListeners();
     }
@@ -220,7 +221,22 @@ SauceBrowser.prototype.shutdown = function(err) {
     // make sure the browser shuts down before continuing
     if (self.browser) {
         debug('quitting browser');
-        self.browser.quit(finish_shutdown);          
+
+        var timeout = false;
+        var quit_timeout = setTimeout(function() {
+            debug('timed out waiting for browser to quit');
+            timeout = true;
+            finish_shutdown();
+        }, 10 * 1000);
+
+        self.browser.quit(function(err) {
+            if (timeout) {
+                return;
+            }
+            
+            clearTimeout(quit_timeout);
+            finish_shutdown();
+        });
     }
     else {
         finish_shutdown();


### PR DESCRIPTION
I was getting a problem whenever I ran my tests on SauceLabs (locally or from Travis) where the last browser in any series would always show the error "Test did not see a new command for 90 seconds. Timing out." (I don't know if this is the same bug as #76). Upon inspection of the SauceLabs logs, I noticed the last browser was not receiving a quit command (DELETE /session/:id).

In SauceBrowser, prior to df0ed8d, SauceBrowser.shutdown was called by the browser.quit callback upon test completion. Afterwards, it was called outside the callback. Moving it outside seems to allow the tunnel to be shut down prior to the browser receiving its shutdown command, leaving SauceLabs hanging. Downgrading to 1.16.1 fixed the issue.

Seeing as SauceBrowser.shutdown already calls browser.quit, I removed the browser.quit call from reporter.on 'done' callback, and rearranged SauceBrowser.shutdown to quit the browser first if it exists, and then continue shutting down in the browser.quit callback.