### PR TITLE
prevent error in fetching sauce results from crashing zuul

### DIFF
--- a/lib/SauceBrowser.js
+++ b/lib/SauceBrowser.js
@@ -164,13 +164,10 @@ SauceBrowser.prototype.start = function() {
                         browser.eval(js, function(err, res) {
                             if (err) {
                                 debug('err: %s', err.message);
+                                return self.shutdown(err);
                             }
 
                             debug('res.length: %s', res.length);
-
-                            if (err) {
-                                return self.shutdown(err);
-                            }
 
                             var has_done = false;
                             res = res || [];
@@ -233,7 +230,7 @@ SauceBrowser.prototype.shutdown = function(err) {
             if (timeout) {
                 return;
             }
-            
+
             clearTimeout(quit_timeout);
             finish_shutdown();
         });


### PR DESCRIPTION
While running iOS tests, I had an error in SauceBrowser when trying to get the test results. Eval returned an error (something about "Return statements are only valid inside functions"; more Sauce logs below if you're curious). I have no idea why that error occurred, but it ended up crashing zuul. When wd's eval encounters an error, [the callback is called without a response object](https://github.com/admc/wd/blob/master/lib/commands.js#L140), so the debug line for the response length throws an error.

I moved the shutdown line into the first error check and removed the superfluous second check. This shouldn't adversely affect the debugging of the response, since if there's an error, there won't be a response.

Sauce logs for curiosity:
```
2092015-01-12 08:02:10:081 - info: [debug] Device launched! Ready for commands
2102015-01-12 08:02:10:082 - info: [debug] Setting command timeout to the default of 60 secs
2112015-01-12 08:02:10:082 - info: [debug] Appium session started with sessionId 680413d3-7dcc-4452-909c-f7920d8e994b
2122015-01-12 08:02:10:086 - info: <-- POST /wd/hub/session 303 40886.327 ms - 9
2132015-01-12 08:02:10:177 - info: [debug] [REMOTE] Receiving data from remote debugger
2142015-01-12 08:02:10:177 - info: [debug] [REMOTE] got applicationSentData response
2152015-01-12 08:02:10:177 - info: [debug] [REMOTE] Page loaded, verifying whether ready through readyState
2162015-01-12 08:02:10:194 - info: [debug] [REMOTE] Receiving data from remote debugger
2172015-01-12 08:02:10:194 - info: [debug] [REMOTE] got applicationSentData response
2182015-01-12 08:02:10:194 - info: [debug] [REMOTE] Got a blank data response from debugger
2192015-01-12 08:02:10:196 - info: [debug] [REMOTE] Receiving data from remote debugger
2202015-01-12 08:02:10:196 - info: [debug] [REMOTE] got applicationSentData response
2212015-01-12 08:02:10:196 - info: [debug] [REMOTE] Got a blank data response from debugger
2222015-01-12 08:02:10:211 - info: [debug] [REMOTE] Receiving data from remote debugger
2232015-01-12 08:02:10:211 - info: [debug] [REMOTE] got applicationSentData response
2242015-01-12 08:02:10:211 - info: [debug] [REMOTE] Got a blank data response from debugger
2252015-01-12 08:02:10:404 - info: [debug] [REMOTE] Receiving data from remote debugger
2262015-01-12 08:02:10:404 - info: [debug] [REMOTE] {"__argument":{"WIRApplicationIdentifierKey":"com.apple.mobilesafari","WIRListingKey":{"1":{"WIRPageIdentifierKey":1,"WIRTitleKey":"Apple","WIRURLKey":"http://www.apple.com/"}}},"__selector":"_rpc_applicationSentListing:"}
2272015-01-12 08:02:10:405 - info: [debug] Remote debugger notified us of a new page listing
2282015-01-12 08:02:10:405 - info: [debug] New page listing from remote debugger doesn't contain current window, let's assume it's closed
2292015-01-12 08:02:10:405 - error: Don't have our current window anymore, and there aren't any more to load! Doing nothing...
2302015-01-12 08:02:10:678 - info: [debug] [REMOTE] Checking document readyState
2312015-01-12 08:02:10:678 - info: [debug] [REMOTE] Sending javascript command
2322015-01-12 08:02:10:679 - info: [debug] [REMOTE] Sending _rpc_forwardSocketData: message to remote debugger
2332015-01-12 08:02:10:817 - info: --> POST /wd/hub/session/680413d3-7dcc-4452-909c-f7920d8e994b/url {"url":"https://mepsdlfoaw.localtunnel.me/__zuul"}
2342015-01-12 08:02:10:819 - info: [debug] Responding to client with success: {"status":0,"value":"","sessionId":"680413d3-7dcc-4452-909c-f7920d8e994b"}
2352015-01-12 08:02:10:820 - info: <-- POST /wd/hub/session/680413d3-7dcc-4452-909c-f7920d8e994b/url 200 3.730 ms - 74 {"status":0,"value":"","sessionId":"680413d3-7dcc-4452-909c-f7920d8e994b"}
2362015-01-12 08:02:11:264 - info: --> POST /wd/hub/session/680413d3-7dcc-4452-909c-f7920d8e994b/execute {"args":[],"script":"return (window.zuul_msg_bus ? window.zuul_msg_bus.splice(0, 10) : []);;"}
2372015-01-12 08:02:11:265 - info: [debug] Pushing command to appium work queue: "return (window.zuul_msg_bus ? window.zuul_msg_bus.splice(0, 10) : []);;"
2382015-01-12 08:02:11:265 - info: [debug] Sending command to instruments: return (window.zuul_msg_bus ? window.zuul_msg_bus.splice(0, 10) : []);;
2392015-01-12 08:02:11:286 - info: [debug] [INST] 2015-01-12 08:02:11 +0000 Debug: Got new command 6 from instruments: return (window.zuul_msg_bus ? window.zuul_msg_bus.splice(0, 10) : []);;
2402015-01-12 08:02:11:292 - info: [debug] [INST] 2015-01-12 08:02:11 +0000 Debug: evaluating return (window.zuul_msg_bus ? window.zuul_msg_bus.splice(0, 10) : []);;
2412015-01-12 08:02:11:438 - info: [debug] Socket data received (75 bytes)
2422015-01-12 08:02:11:438 - info: [debug] Socket data being routed.
2432015-01-12 08:02:11:438 - info: [debug] Got result from instruments: {"status":17,"value":"Return statements are only valid inside functions"}
2442015-01-12 08:02:11:439 - info: [debug] Responding to client with error: {"status":17,"value":{"message":"An error occurred while executing user supplied JavaScript.","origValue":"Return statements are only valid inside functions"},"sessionId":"680413d3-7dcc-4452-909c-f7920d8e994b"}
2452015-01-12 08:02:11:440 - info: <-- POST /wd/hub/session/680413d3-7dcc-4452-909c-f7920d8e994b/execute 500 175.579 ms - 210
```
