### PR TITLE
Make the tunnel pluggable

### DIFF
--- a/bin/zuul
+++ b/bin/zuul
@@ -106,6 +106,10 @@ if (program.browserName) {
     config = xtend(config, { browsers: [{ name: program.browserName, version: program.browserVersion, platform: program.browserPlatform }] });
 }
 
+if (typeof program.tunnel === 'string') {
+    config.tunnel.type = program.tunnel;
+}
+
 // optional additional local config or from $HOME/.zuulrc
 var local_config = find_nearest_file('.zuulrc') || path.join(osenv.home(), '.zuulrc');
 if (fs.existsSync(local_config)) {

--- a/bin/zuul
+++ b/bin/zuul
@@ -20,7 +20,7 @@ program
 .usage('[options] <files | dir>')
 .option('--ui <testing ui>', 'ui for tests (mocha-bdd, mocha-tdd, qunit, tape)')
 .option('--local [port]', 'port for manual testing in a local browser')
-.option('--tunnel', 'establish a tunnel for outside access. only used when --local is specified')
+.option('--tunnel [type]', 'establish a tunnel for outside access. only used when --local is specified')
 .option('--phantom', 'run tests in phantomjs. PhantomJS must be installed separately.')
 .option('--tunnel-host <host url>', 'specify a localtunnel server to use for forwarding')
 .option('--sauce-connect [tunnel-identifier]', 'use saucelabs with sauce connect instead of localtunnel. Optionally specify the tunnel-identifier')

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -1,5 +1,4 @@
 var bouncy = require('bouncy');
-var tunnel = require('localtunnel');
 var debug = require('debug')('zuul:setup');
 
 var user_server = require('./user-server');
@@ -10,8 +9,12 @@ var user_server = require('./user-server');
 function setup_test_instance(opt, cb) {
 
     var support_server = undefined;
-    var localtunnel = undefined;
     var bouncer = undefined;
+    var Tunnel = (typeof opt.tunnel === 'string') ?
+        require('zuul-' + opt.tunnel) :
+        require('zuul-localtunnel');
+
+    var tunnel = new Tunnel(opt);
 
     if (opt.server) {
         user_server(opt.server, setup);
@@ -62,24 +65,13 @@ function setup_test_instance(opt, cb) {
                 return cb(null, 'http://localhost:' + app_port + '/__zuul');
             }
 
-            tunnel(app_port, { host: config.tunnel_host || 'http://localtunnel.me' }, function(err, lt) {
-                if (err) {
-                    return cb(err);
-                }
-
-                var url = lt.url + '/__zuul';
-                localtunnel = lt;
-                cb(null, url);
-            });
+            tunnel.connect(app_port, cb);
         };
     }
 
     function shutdown() {
         bouncer.close();
-
-        if (localtunnel) {
-            localtunnel.close();
-        }
+        tunnel.close();
 
         if (support_server) {
             support_server.process.kill('SIGKILL');

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -10,9 +10,14 @@ function setup_test_instance(opt, cb) {
 
     var support_server = undefined;
     var bouncer = undefined;
-    var Tunnel = (typeof opt.tunnel === 'string') ?
-        require('zuul-' + opt.tunnel) :
-        require('zuul-localtunnel');
+    var Tunnel;
+    if (typeof opt.tunnel === 'string') {
+        Tunnel = require('zuul-' + opt.tunnel);
+    } else if (typeof opt.tunnel === 'object' && opt.tunnel.type) {
+        Tunnel = require('zuul-' + opt.tunnel.type);
+    } else {
+        Tunnel = require('zuul-localtunnel');
+    }
 
     var tunnel = new Tunnel(opt);
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "hbs": "2.4.0",
     "highlight.js": "7.5.0",
     "load-script": "0.0.5",
-    "localtunnel": "1.5.0",
+    "zuul-localtunnel": "0.0.1",
     "lodash": "2.4.1",
     "opener": "1.4.0",
     "osenv": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "hbs": "2.4.0",
     "highlight.js": "7.5.0",
     "load-script": "0.0.5",
-    "zuul-localtunnel": "0.0.1",
+    "zuul-localtunnel": "1.0.1",
     "lodash": "2.4.1",
     "opener": "1.4.0",
     "osenv": "0.0.3",


### PR DESCRIPTION
- The used tunnel type can be plugged in to zuul by specifying the optional argument to `--tunnel`, such as `--tunnel ngrok`, which will require the `zuul-ngrok` package, or `--tunnel localtunnel` (the default when just doing `--tunnel`), which will require `zuul-localtunnel`.
- Additional configuration needed by the specified tunnel type can be put in `.zuul.yml`, such as the `authtoken` option required by `zuul-ngrok`.

Example of additional configuration:
```
ui: mocha-bdd
authtoken: <token here as needed by ngrok>
browsers: 
  - name: chrome
    version: 29..latest
```

The required `zuul-localtunnel` dependency is not published yet but can be found [here](https://github.com/rase-/zuul-localtunnel). The `ngrok` implementation can be found [here](https://github.com/rase-/zuul-ngrok). To try them out, I simply symlink the two repos to `node_modules` of the project I want to try them with.

What do you think of this type of separation, @defunctzombie?