### PR TITLE
Add support for a platform array

### DIFF
--- a/lib/flatten_browser.js
+++ b/lib/flatten_browser.js
@@ -16,9 +16,18 @@ function flatten(request, all_browsers) {
         // clone because we will modify to filter down
         var avail = all_browsers[req.name].slice(0);
 
-        if (req.platform) {
+        if (req.platform && typeof req.platform === 'string') {
             avail = avail.filter(function(browser) {
-                return req.platform.toLowerCase() === browser.platform.toLowerCase()
+                return req.platform.toLowerCase() === browser.platform.toLowerCase();
+            });
+        }
+        else if (req.platform && Array.isArray(req.platform)) {
+            req.platform = req.platform.map(function(platform) {
+                return platform.toLowerCase();
+            });
+
+            avail = avail.filter(function(browser) {
+                return req.platform.indexOf(browser.platform.toLowerCase()) > -1;
             });
         }
 
@@ -42,12 +51,15 @@ function flatten(request, all_browsers) {
 
         // remove duplicate version entries
         // because we are not interested in testing on all platforms
-        avail.reduce(function(prev, curr, idx, arr) {
-            if (prev && prev.version === curr.version) {
-                arr[idx] = undefined;
-            }
-            return curr;
-        });
+        // unless explicitly asked
+        if (!req.platform) {
+            avail.reduce(function(prev, curr, idx, arr) {
+                if (prev && prev.version === curr.version) {
+                    arr[idx] = undefined;
+                }
+                return curr;
+            });
+        }
 
         avail = avail.filter(Boolean);
 
@@ -69,10 +81,26 @@ function flatten(request, all_browsers) {
         function process_version_str(version) {
             version = String(version);
             if (version === 'latest') {
-                return get_numeric_versions(avail).slice(-1).map(addProfile);
+                if (Array.isArray(req.platform)) {
+                    var latest = get_numeric_versions(avail).slice(-1)[0].version;
+                    return avail.filter(function(browser) {
+                        return browser.version === latest;
+                    });
+                }
+                else {
+                    return get_numeric_versions(avail).slice(-1).map(addProfile);
+                }
             }
             else if (version === 'oldest') {
-                return avail.slice(0, 1).map(addProfile);
+                if (Array.isArray(req.platform)) {
+                    var oldest = get_numeric_versions(avail).slice(0, 1)[0].version;
+                    return avail.filter(function(browser) {
+                        return browser.version === oldest;
+                    });
+                }
+                else {
+                    return avail.slice(0, 1).map(addProfile);
+                }
             }
 
             // split version string on two dots to see if range was specified


### PR DESCRIPTION
Let's you specify browser platforms as an array.

Example config:
```
ui: mocha-bdd
browsers: 
  - name: chrome
    version: [35,38,latest]
    platform: [Mac 10.10, Linux, Windows 2012]
```

Also simple `latest` and `oldest` version strings take all the specified platforms if an array is specified, for those platforms that have that browser version available.