### PR TITLE
Fix tunnel options in `SauceBrowser`

### DIFF
--- a/lib/SauceBrowser.js
+++ b/lib/SauceBrowser.js
@@ -14,7 +14,7 @@ function SauceBrowser(conf, opt) {
     var self = this;
     self._conf = conf;
     self._opt = opt;
-    self._opt.tunnel = !opt.sauce_connect;
+    self._opt.tunnel = (opt.sauce_connect) ? false : self._opt.tunnel;
     self.stats = {
         passed: 0,
         failed: 0


### PR DESCRIPTION
Make the sauce browser use the tunnel option if `sauce_connect` is not defined.