### PR TITLE
Fix sauce browser default tunnel option value

### DIFF
--- a/lib/SauceBrowser.js
+++ b/lib/SauceBrowser.js
@@ -14,7 +14,7 @@ function SauceBrowser(conf, opt) {
     var self = this;
     self._conf = conf;
     self._opt = opt;
-    self._opt.tunnel = (opt.sauce_connect) ? false : self._opt.tunnel;
+    self._opt.tunnel = (opt.sauce_connect) ? false : (self._opt.tunnel || true);
     self.stats = {
         passed: 0,
         failed: 0


### PR DESCRIPTION
Fixes unestablished tunnel if no tunnel option specified and not using sauce connect.