### PR TITLE
Regsiter Istanbul transform after custom Browserify transforms

### DIFF
--- a/lib/builder-browserify.js
+++ b/lib/builder-browserify.js
@@ -36,13 +36,13 @@ module.exports = function (files, config, cb) {
 
     var bundler = browserify(browserifyOptions);
 
+    configure(bundler, config.browserify);
+    
     if (config.coverage && config.local) {
         bundler.transform(istanbul({
             defaultIgnore: true
         }));
     }
-
-    configure(bundler, config.browserify);
 
     files.forEach(function(file) {
         bundler.require(file, { entry: true });


### PR DESCRIPTION
### Current problem

If writing a test that depends on a source file that requires additional transforms, like `coffeeify` or `reactify`, the Zuul test runner will fail because the istanbul transform will be applied before the custom transforms in **.zuul.yml**, and throw various parser errors.

### Proposed solution

Simply place the call to `bundler.transform(istanbul, ...)` **after** the call to `configure(bundler, config.browserify)`.