### PR TITLE
Make it possible to add transform options

### DIFF
--- a/lib/builder-browserify.js
+++ b/lib/builder-browserify.js
@@ -17,7 +17,11 @@ function configure (bundler, cfg) {
     }
 
     function register (type, o) {
-        bundler[type](o[type], _.omit(o, type));
+        if ('transform' === type && 'object' === typeof o[type]) {
+            bundler[type](o[type].name, _.omit(o[type], 'name'));
+        } else {
+            bundler[type](o[type], _.omit(o, type));
+        }
     }
 }
 
@@ -37,7 +41,7 @@ module.exports = function (files, config, cb) {
     var bundler = browserify(browserifyOptions);
 
     configure(bundler, config.browserify);
-    
+
     if (config.coverage && config.local) {
         bundler.transform(istanbul({
             defaultIgnore: true


### PR DESCRIPTION
Allows specifying transform specific options with the following syntax:

```yaml
browserify:
  - transform:
      name: reactify
      es6: true
  - transform: 6to5ify # "normal" syntax, no options
```