### PR TITLE
rework tape client, add tape ui tests

### DIFF
--- a/bin/zuul
+++ b/bin/zuul
@@ -204,8 +204,9 @@ scout_browser(function(err, all_browsers) {
         zuul.browser(info);
     });
 
-    var passed_count = 0;
-    var failed_count = 0;
+    var passed_tests_count = 0;
+    var failed_tests_count = 0;
+    var failed_browsers_count = 0;
 
     zuul.on('browser', function(browser) {
         var name = browser.toString();
@@ -249,8 +250,12 @@ scout_browser(function(err, all_browsers) {
         });
 
         browser.once('done', function(results) {
-            passed_count += results.passed;
-            failed_count += results.failed;
+            passed_tests_count += results.passed;
+            failed_tests_count += results.failed;
+
+            if (results.failed > 0) {
+                failed_browsers_count++;
+            }
 
             if (results.failed || results.passed === 0) {
                 console.log('- failed: %s (%d failed, %d passed)'.red, name,
@@ -267,17 +272,17 @@ scout_browser(function(err, all_browsers) {
     });
 
     zuul.run(function(passed) {
-        if (failed_count > 0) {
-            console.log('%d browser(s) failed'.red, failed_count);
+        if (failed_tests_count > 0) {
+            console.log('%d browser(s) failed'.red, failed_browsers_count);
         }
-        else if (passed_count === 0) {
+        else if (passed_tests_count === 0) {
             console.log('no tests ran'.yellow);
         }
         else {
             console.log('all browsers passed'.green);
         }
 
-        process.exit((passed_count > 0 && failed_count == 0) ? 0 : 1);
+        process.exit((passed_tests_count > 0 && failed_tests_count == 0) ? 0 : 1);
     });
 });
 

--- a/frameworks/tape/client.js
+++ b/frameworks/tape/client.js
@@ -94,7 +94,7 @@ parse_stream.on('assert', function(assert) {
         result: assert.ok,
         expected: undefined,
         actual: undefined,
-        message: assert.name,
+        message: assert.name || 'unnamed assert',
         error: undefined,
         stack: undefined
     });

--- a/frameworks/tape/client.js
+++ b/frameworks/tape/client.js
@@ -1,5 +1,4 @@
 var parser = require('tap-parser');
-var inspect = require('util').inspect;
 
 var ZuulReporter = require('../zuul');
 
@@ -11,64 +10,27 @@ var reporter = ZuulReporter(run);
 var previous_test = undefined;
 var assertions = 0;
 var done = false;
-var got_test_num = false;
-var got_pass_num = false;
 
-var parse_stream = parser(function(results) {
-    reporter.done();
-});
+var parse_stream = parser();
 
-var originalLog = console.log;
-console.log = function () {
-    var index = 1;
-    var args = arguments;
-    var msg = args[0];
 var originalLog = global.console.log;
 global.console.log = function () {
+    var msg = arguments[0];
 
-    if (!msg) {
-        return;
+    // do not write in a closed WriteStream
+    if (!done) {
+        parse_stream.write(msg + '\n');
     }
 
-    if (typeof msg === 'string') {
-        msg = msg.replace(/(^|[^%])%[sd]/g, function (_, s) {
-            return s + args[index++];
-        });
-    }
-    else msg = inspect(msg);
-
-    for (var i = index; i < args.length; i++) {
-        msg += ' ' + inspect(args[i]);
-    }
-
-    parse_stream.write(msg + '\n');
-
-    if (/^# tests( )*\d/.test(msg)) {
-      got_test_num = true;
-    }
-
-    if (/^# pass( )*\d/.test(msg)) {
-      originalLog.call(this, 'got', msg);
-      got_pass_num = true;
-    }
-
-    if ((/^# fail\s*\d+$/.test(msg) || /^# ok/.test(msg)) && got_test_num && got_pass_num) {
-        parse_stream.end();
-    }
-
+    // transfer log to original console,
+    // this shows the tap output in console
+    // and also let the user add console logs
     if (typeof originalLog === 'function') {
         return originalLog.apply(this, arguments);
-    }
-    else if (originalLog) {
-        return originalLog(arguments[0]);
     }
 };
 
 parse_stream.on('comment', function(comment) {
-    if (done) {
-        return;
-    }
-
     if (previous_test) {
         reporter.test_end({
             passed: assertions === 0,
@@ -111,9 +73,12 @@ parse_stream.on('plan', function(plan) {
             name: previous_test.name
         });
     }
+
+    parse_stream.end();
+    reporter.done();
 });
 
 function run() {
-  // tape tests already start by default
-  // I don't like this stuff, very annoying to interface with
+    // tape tests already start by default
+    // I don't like this stuff, very annoying to interface with
 }

--- a/frameworks/tape/client.js
+++ b/frameworks/tape/client.js
@@ -3,8 +3,8 @@ var inspect = require('util').inspect;
 
 var ZuulReporter = require('../zuul');
 
-if (typeof console === 'undefined') {
-    console = {};
+if (typeof global.console === 'undefined') {
+    global.console = {};
 }
 
 var reporter = ZuulReporter(run);
@@ -23,6 +23,8 @@ console.log = function () {
     var index = 1;
     var args = arguments;
     var msg = args[0];
+var originalLog = global.console.log;
+global.console.log = function () {
 
     if (!msg) {
         return;

--- a/lib/PhantomBrowser.js
+++ b/lib/PhantomBrowser.js
@@ -5,6 +5,7 @@ var Split = require('char-split');
 var debug = require('debug')('zuul:phantombrowser');
 
 var setup_test_instance = require('./setup');
+require('colors');
 
 function PhantomBrowser(opt) {
     if (!(this instanceof PhantomBrowser)) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "highlight.js": "7.5.0",
     "istanbul-middleware": "0.2.0",
     "load-script": "0.0.5",
-    "zuul-localtunnel": "1.0.1",
     "lodash": "2.4.1",
     "opener": "1.4.0",
     "osenv": "0.0.3",
@@ -32,11 +31,12 @@
     "stacktrace-js": "defunctzombie/stacktrace.js#07e7b95",
     "superagent": "0.15.7",
     "superstack": "0.0.4",
-    "tap-parser": "0.4.1",
-    "tape": "2.3.2",
+    "tap-parser": "0.7.0",
+    "tape": "3.5.0",
     "wd": "0.3.11",
     "xtend": "2.1.2",
-    "yamljs": "0.1.4"
+    "yamljs": "0.1.4",
+    "zuul-localtunnel": "1.0.1"
   },
   "devDependencies": {
     "mocha": "~1.16.2",

--- a/test/index.js
+++ b/test/index.js
@@ -164,6 +164,38 @@ test('mocha-qunit - sauce', function(done) {
     });
 });
 
+test('tape - phantom', function(done) {
+    done = after(3, done);
+
+    var config = {
+        ui: 'tape',
+        prj_dir: __dirname + '/tape',
+        phantom: true,
+        concurrency: 1,
+        files: [__dirname + '/tape/test.js']
+    };
+
+    var zuul = Zuul(config);
+
+    // each browser we test will emit as a browser
+    zuul.on('browser', function(browser) {
+        browser.on('init', function() {
+            done();
+        });
+
+        browser.on('done', function(results) {
+            assert.equal(results.passed, 3);
+            assert.equal(results.failed, 3);
+            done();
+        });
+    });
+
+    zuul.run(function(passed) {
+        assert.ok(!passed);
+        done();
+    });
+});
+
 test('capabilities config', function(done) {
     var config = {
         ui: 'mocha-bdd',

--- a/test/tape/test.js
+++ b/test/tape/test.js
@@ -1,0 +1,48 @@
+var test = require('tape');
+
+// https://github.com/defunctzombie/zuul/issues/145
+test('ok', function(t) {
+    t.pass();
+    t.end();
+});
+
+// https://github.com/defunctzombie/zuul/issues/145
+test('fail', function(t) {
+    t.ok(false);
+    t.end();
+});
+
+test('suite', function(t) {
+    t.ok(true, 'yeah');
+    t.ok(false, 'WOOPS');
+    t.fail(false);
+    t.end();
+});
+
+test('pass', function(t) {
+    t.pass();
+    t.end();
+});
+
+test('plan', function(t) {
+    t.plan(1);
+
+    setTimeout(function() {
+        t.ok(true === true, 'true is true AWESOME');
+    }, 10);
+});
+
+test('failed plan', {timeout: 200}, function(t) {
+    t.plan(2);
+    t.ok(true, 'one assert');
+});
+
+// nothing to be done
+test.skip('skipped', function(t) {
+    t.ok(false);
+});
+
+// test console still ok
+console.log({hey: 'you'});
+console.debug([1,2,3]);
+console.log(1,2,[3,4]);


### PR DESCRIPTION
Context: I wanted to add a feature to zuul (incoming later).

I looked the zuul tests, saw no tape test.

I like tape (you don't, no prob :p)

Added a test, it failed, had to redo the tape/client.js,
we did not call reporter.done() for instance.

Also I did not see any value in our whole message parsing/logging on top
of tap-parser.

This version works well, in local mode, phantomjs, saucelabs.

It even seems to fix corner cases with timeouted tests and failed plans.

I tried to add as many tests as possible, let me know.

PS: while debugging and hacking I found other bugs that I fixed in different commits