### PR TITLE
fix tape client finished state

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "stacktrace-js": "defunctzombie/stacktrace.js#07e7b95",
     "superagent": "0.15.7",
     "superstack": "0.0.4",
+    "tap-finished": "0.0.1",
     "tap-parser": "0.7.0",
     "tape": "3.5.0",
     "wd": "0.3.11",

--- a/test/index.js
+++ b/test/index.js
@@ -166,6 +166,7 @@ test('mocha-qunit - sauce', function(done) {
 
 test('tape - phantom', function(done) {
     done = after(3, done);
+    var consoleOutput = [];
 
     var config = {
         ui: 'tape',
@@ -179,11 +180,28 @@ test('tape - phantom', function(done) {
 
     // each browser we test will emit as a browser
     zuul.on('browser', function(browser) {
+        browser.on('start', function(reporter) {
+            reporter.on('console', function(msg) {
+                consoleOutput.push(msg.args);
+            });
+        });
+
         browser.on('init', function() {
             done();
         });
 
         browser.on('done', function(results) {
+            var endOfOutput = consoleOutput.slice(-5);
+
+            // check that we did output untill the end of the test suite
+            // this is the number of asserts in tape
+            assert.deepEqual(endOfOutput[0], ['1..9']);
+            assert.deepEqual(endOfOutput[1], ['# tests 9']);
+            assert.deepEqual(endOfOutput[2], ['# pass  5']);
+            assert.deepEqual(endOfOutput[3], ['# fail  4']);
+            assert.deepEqual(endOfOutput[4], ['']);
+
+            // this is the number of passed/failed test() in tape
             assert.equal(results.passed, 3);
             assert.equal(results.failed, 3);
             done();


### PR DESCRIPTION
Before this PR, the tape client would not output

1..9

At the end of tests when using phantombrowser for example, because we
closed the stream too early.

I am using tape-finished because that's the only easy way to know when a
tap suite is finished.

Otherwise we would have to parse 1..9, #tests 9 ourselves.

That's what was done before using regexps. now in a module so we do not care.