### PR TITLE
put default admc/wd options

### DIFF
--- a/lib/SauceBrowser.js
+++ b/lib/SauceBrowser.js
@@ -43,8 +43,8 @@ SauceBrowser.prototype.start = function() {
     var browser = self.browser = wd.remote('ondemand.saucelabs.com', 80, conf.username, conf.key);
 
     browser.configureHttp({
-        timeout: undefined,
-        retries: 1,
+        timeout: 60 * 1000,
+        retries: 3,
         retryDelay: 1000
     });
 


### PR DESCRIPTION
Following #159. I know you are "down" for hight timeouts so I did not put higher timeouts but only setup admc/wd options as per the doc: https://github.com/admc/wd/#http-configuration--base-url

I cannot guarantee this will fix the .get() timeouts (https://github.com/defunctzombie/zuul/issues/129#issuecomment-72752754) issues but at least we will be more in control of what's hapening.