### PR TITLE
Make browser versions ending with `.0` work

### DIFF
--- a/lib/flatten_browser.js
+++ b/lib/flatten_browser.js
@@ -140,7 +140,10 @@ function flatten(request, all_browsers) {
             }
 
             return avail.filter(function(browser) {
-                return browser.version == version;
+                // JS will forget about the .0 when reading any float that can
+                // be represented as an integer from yaml, so let's try to
+                // match a version of that form as a fallback
+                return browser.version == version || browser.version == version + '.0';
             }).map(addProfile);
 
             function get_numeric_versions(browsers) {


### PR DESCRIPTION
Versions like `6.0` will be considered as just `6` unless they are wrapped in quotes. Let's try the version and an appenden `.0` when finding matching browser versions.

Fixes https://github.com/defunctzombie/zuul/issues/163