### PR TITLE
Show browser name and version in sauce debug name

### DIFF
--- a/lib/SauceBrowser.js
+++ b/lib/SauceBrowser.js
@@ -1,7 +1,7 @@
 var wd = require('wd');
 var EventEmitter = require('events').EventEmitter;
 var FirefoxProfile = require('firefox-profile');
-var debug = require('debug')('zuul:saucebrowser');
+var debug = require('debug');
 var xtend = require('xtend');
 
 var setup_test_instance = require('./setup');
@@ -19,6 +19,7 @@ function SauceBrowser(conf, opt) {
         passed: 0,
         failed: 0
     };
+    self.debug = debug('zuul:sauce:' + conf.browser + ':' + conf.version);
 }
 
 SauceBrowser.prototype.__proto__ = EventEmitter.prototype;
@@ -39,7 +40,7 @@ SauceBrowser.prototype.start = function() {
         failed: 0
     };
 
-    debug('running %s %s %s', conf.browser, conf.version, conf.platform);
+    self.debug('running');
     var browser = self.browser = wd.remote('ondemand.saucelabs.com', 80, conf.username, conf.key);
 
     self.controller = setup_test_instance(self._opt, function(err, url) {
@@ -89,7 +90,7 @@ SauceBrowser.prototype.start = function() {
         }
 
         function init() {
-            debug('queuing %s %s %s', conf.browser, conf.version, conf.platform);
+            self.debug('queuing');
 
             browser.init(init_conf, function(err) {
                 if (err) {
@@ -109,7 +110,7 @@ SauceBrowser.prototype.start = function() {
                 });
 
                 reporter.on('done', function(results) {
-                    debug('done %s %s %s', conf.browser, conf.version, conf.platform);
+                    self.debug('done');
                     var passed = results.passed;
                     var called = false;
                     browser.sauceJobStatus(passed, function(err) {
@@ -129,12 +130,12 @@ SauceBrowser.prototype.start = function() {
                     reporter.removeAllListeners();
                 });
 
-                debug('open %s', url);
+                self.debug('open %s', url);
                 self.emit('start', reporter);
 
                 var timeout = false;
                 var get_timeout = setTimeout(function() {
-                    debug('timed out waiting for open %s', url);
+                    self.debug('timed out waiting for open %s', url);
                     timeout = true;
                     self.shutdown(new Error('Timeout opening url'));
                 }, 120 * 1000);
@@ -154,15 +155,15 @@ SauceBrowser.prototype.start = function() {
                             return;
                         }
 
-                        debug('waiting for test results from %s', url);
+                        self.debug('waiting for test results from %s', url);
                         var js = '(window.zuul_msg_bus ? window.zuul_msg_bus.splice(0, 10) : []);'
                         browser.eval(js, function(err, res) {
                             if (err) {
-                                debug('err: %s', err.message);
+                                self.debug('err: %s', err.message);
                                 return self.shutdown(err);
                             }
 
-                            debug('res.length: %s', res.length);
+                            self.debug('res.length: %s', res.length);
 
                             var has_done = false;
                             res = res || [];
@@ -175,11 +176,11 @@ SauceBrowser.prototype.start = function() {
                             });
 
                             if (has_done) {
-                                debug('finished tests for %s', url);
+                                self.debug('finished tests for %s', url);
                                 return;
                             }
 
-                            debug('fetching more results');
+                            self.debug('fetching more results');
                             setTimeout(wait, 1000);
                         });
                     })();
@@ -195,7 +196,7 @@ SauceBrowser.prototype.shutdown = function(err) {
     self.stopped = true;
 
     var finish_shutdown = function () {
-        debug('shutdown');
+        self.debug('shutdown');
 
         if (self.controller) {
             self.controller.shutdown();
@@ -212,11 +213,11 @@ SauceBrowser.prototype.shutdown = function(err) {
 
     // make sure the browser shuts down before continuing
     if (self.browser) {
-        debug('quitting browser');
+        self.debug('quitting browser');
 
         var timeout = false;
         var quit_timeout = setTimeout(function() {
-            debug('timed out waiting for browser to quit');
+            self.debug('timed out waiting for browser to quit');
             timeout = true;
             finish_shutdown();
         }, 10 * 1000);


### PR DESCRIPTION
And rename `saucebrowser` to just `sauce` in the saucebrowser debug name.

![pic](https://cloudup.com/cSs8lNoz9oo+)

Fixes https://github.com/defunctzombie/zuul/issues/134