### PR TITLE
Register browserify config in the same order as zuul.yml

### DIFF
--- a/lib/builder-browserify.js
+++ b/lib/builder-browserify.js
@@ -13,13 +13,29 @@ function configure(bundler, cfg) {
         return;
     }
 
-    ['plugin', 'external', 'ignore', 'exclude', 'transform', 'add', 'require'].forEach(registerable);
+    var registerableCfg = [
+        'plugin',
+        'external',
+        'ignore',
+        'exclude',
+        'transform',
+        'add',
+        'require'
+    ];
 
-    function registerable (type) {
-        _.where(cfg, type).forEach(register.bind(null, type));
+    cfg.forEach(registerable);
+
+    // grab registerable configs and register them
+    function registerable (cfgObj) {
+        _.forIn(cfgObj, function(value, key) {
+            if (registerableCfg.indexOf(key) !== -1) {
+                register(key, cfgObj);
+            }
+        });
     }
 
     function register (type, o) {
+        debug('registering %s: %s', type, o[type]);
         if (type === 'transform' && typeof o[type] === 'object') {
             bundler[type](o[type].name, _.omit(o[type], 'name'));
         } else {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "after": "~0.8.1",
     "mocha": "~1.16.2",
     "phantomjs": "1.9.12",
-    "through2": "^0.6.3"
+    "through2": "0.6.3"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -42,9 +42,10 @@
     "zuul-localtunnel": "1.1.0"
   },
   "devDependencies": {
-    "mocha": "~1.16.2",
     "after": "~0.8.1",
-    "phantomjs": "1.9.12"
+    "mocha": "~1.16.2",
+    "phantomjs": "1.9.12",
+    "through2": "^0.6.3"
   },
   "repository": {
     "type": "git",

--- a/test/builder-browserify/bar-to-baz-plugin.js
+++ b/test/builder-browserify/bar-to-baz-plugin.js
@@ -1,0 +1,15 @@
+// test browserify plugin
+// changes all instances of 'bar' to 'baz'
+
+// changes all instances of 'bar' to 'baz'
+var through = require('through2');
+var barToBazTransform = function (file) {
+    return through(function (buf, enc, next) {
+        this.push(buf.toString('utf8').replace(/bar/g, 'baz'));
+        next();
+    });
+};
+
+module.exports = function (b, opts) {
+    b.transform(barToBazTransform);
+};

--- a/test/builder-browserify/baz-to-qux-transform.js
+++ b/test/builder-browserify/baz-to-qux-transform.js
@@ -1,0 +1,9 @@
+// test browserify transform
+// changes all instances of 'baz' to 'qux'
+var through = require('through2');
+module.exports = function (file) {
+    return through(function (buf, enc, next) {
+        this.push(buf.toString('utf8').replace(/baz/g, 'qux'));
+        next();
+    });
+};

--- a/test/builder-browserify/entry.js
+++ b/test/builder-browserify/entry.js
@@ -1,0 +1,2 @@
+// test entry file for browserify
+console.log('foo');

--- a/test/builder-browserify/foo-to-bar-transform.js
+++ b/test/builder-browserify/foo-to-bar-transform.js
@@ -1,0 +1,9 @@
+// test browserify transform
+// changes all instances of 'foo' to 'bar'
+var through = require('through2');
+module.exports = function (file) {
+    return through(function (buf, enc, next) {
+        this.push(buf.toString('utf8').replace(/foo/g, 'bar'));
+        next();
+    });
+};


### PR DESCRIPTION
I rewrote the configure function in builder-browserify to register browserify options in the same order as they appear in the config.browserify array. This fixes #177.

I added a test to ensure that things are, in fact, registered in order. I just tacked it on the end of the main test file, but if it should be organized a different way, I can change that.

It seems to be working fine with my projects (and fixed the issue I was having with one of them), and all tests are passing. That being said, the builder module doesn't seem to have any existing tests, so I'd ask for a little help making certain it didn't break anything.