### PR TITLE
Builder api static config

### DIFF
--- a/lib/builder-browserify.js
+++ b/lib/builder-browserify.js
@@ -44,14 +44,12 @@ function configure(bundler, cfg) {
     }
 }
 
-// the builder API is var build = require('builder')(); build(files, config, cb)
+// the builder API is var build = require('builder')(files, config); build(cb)
 // So that we can have multiple different `watchifyBundler` caches per build instance.
-module.exports = function() {
-    var watchifyBundler;
+module.exports = function(files, config) {
+    var watchifyBundler = initBundler(files, config);
 
-    return function(files, config, cb) {
-        watchifyBundler = watchifyBundler || initBundler(files, config);
-
+    return function(cb) {
         var start = Date.now();
         watchifyBundler.bundle(function(err, buf) {
             if (err) {

--- a/lib/control-app.js
+++ b/lib/control-app.js
@@ -43,7 +43,7 @@ module.exports = function(config) {
     // default builder is browserify which we provide
     config.builder = config.builder || defaultBuilder;
 
-    build = require(config.builder)();
+    build = require(config.builder)(files, config);
 
     var app = express();
 
@@ -122,7 +122,7 @@ module.exports = function(config) {
     bundle_router.get('/__zuul/test-bundle.js', function(req, res, next) {
         res.contentType('application/javascript');
 
-        build(files, config, function(err, src, srcmap) {
+        build(function(err, src, srcmap) {
             if (err) {
                 return next(err);
             }


### PR DESCRIPTION
We change builder API from

    var builder = makeBuilder()
    builder(files, config, cb)

to

    var builder = makeBuilder(files, config)
    builder(cb)

Which is more in line with how the only current browserify builder is
implemented.

Now it is not intuitive what should happen if builder is supplied with a different config/files arguments. I think it's better to move them into "static" (init) part of builder API so this is inline with how browserify (and even webpack) works.