### PR TITLE
fix TypeError caused when connection header is absent

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -61,7 +61,7 @@ function setup_test_instance(opt, cb) {
             }
 
             var opts = {};
-            if (req.headers.connection.toLowerCase().indexOf('upgrade') === -1) {
+            if (req.headers.connection && req.headers.connection.toLowerCase().indexOf('upgrade') === -1) {
                 opts.headers = { connection: 'close' };
             }
             bounce(support_port, opts);


### PR DESCRIPTION
connection header is not always sent, so it causes the following error:

```
TypeError: Cannot call method 'toLowerCase' of undefined
```

here is an example of req.header when using Sauce Connect:

```
{ host: 'localhost:46768',
  'content-length': '11',
  origin: 'http://localhost:46768',
  'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.76 Safari/537.36',
  'content-type': 'text/plain;charset=UTF-8',
  accept: '*/*',
  referer: 'http://localhost:46768/__zuul',
  'accept-encoding': 'gzip, deflate',
  'accept-language': 'en-US,en;q=0.8',
  via: '1.1 tunnel (squid/3.4.6)',
  'cache-control': 'max-age=0' }
```