### PR TITLE
update convert-source-map and check for large sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "char-split": "0.2.0",
     "colors": "0.6.2",
     "commander": "2.1.0",
-    "convert-source-map": "0.4.1",
+    "convert-source-map": "1.0.0",
     "debug": "2.1.0",
     "express": "3.4.8",
     "express-state": "1.0.3",


### PR DESCRIPTION
ref https://github.com/thlorenz/convert-source-map/pull/18

I'm not sure of a good size for `isLarge` length so I chose 1000 arbitrarily.