### PR TITLE
fix jasmine2 client finished state

### DIFF
--- a/frameworks/jasmine2/client.js
+++ b/frameworks/jasmine2/client.js
@@ -29,7 +29,7 @@ ZuulJasmineReporter.prototype.getFullSpecName = function(spec, separator) {
     return getFullSuiteName(this.suite) + separator + spec.description;
 };
 
-ZuulJasmineReporter.prototype.suiteDone = function () {
+ZuulJasmineReporter.prototype.jasmineDone = function () {
     reporter.done();
 };
 


### PR DESCRIPTION
This pull request fixes https://github.com/defunctzombie/zuul/issues/196

before:

`suiteDone`: called when each describe completes execution

after:

`jasmineDone`: called when the jasmine suite completes execution

----

I'v referenced [event types summary of testing framework](https://github.com/js-reporters/js-reporters/issues/1#issuecomment-54572441).

/cc @vvo @rase- 