### PR TITLE
Add --report option. Writing job statuses to zuul.json

### DIFF
--- a/bin/zuul
+++ b/bin/zuul
@@ -323,7 +323,7 @@ scout_browser(function(err, all_browsers) {
                     console.log('zuul-reporter error:',err.message.red);
                 }
                 else{
-                    var publishKey= new Soysauce().encrypt(statuses,process.env.TRAVIS);
+                    var publishKey= new Soysauce().encrypt(statuses,process.env.TRAVIS_JOB_ID);
                     console.log(publishKey);
                 }
 

--- a/bin/zuul
+++ b/bin/zuul
@@ -16,6 +16,7 @@ var Zuul = require('../lib/zuul');
 var scout_browser = require('../lib/scout_browser');
 var flatten_browser = require('../lib/flatten_browser');
 var zuul_reporter= require('zuul-reporter');
+var Soysauce= require('soysauce');
 
 program
 .version(require('../package.json').version)
@@ -322,8 +323,8 @@ scout_browser(function(err, all_browsers) {
                     console.log('zuul-reporter error:',err.message.red);
                 }
                 else{
-                    fs.writeFileSync(report,JSON.stringify(statuses));
-                    console.log('wrote job statuses to zuul.json'.green);
+                    var publishKey= new Soysauce().encrypt(statuses,process.env.TRAVIS);
+                    console.log(publishKey);
                 }
 
                 process.exit(code);

--- a/bin/zuul
+++ b/bin/zuul
@@ -15,6 +15,7 @@ var _ = require('lodash');
 var Zuul = require('../lib/zuul');
 var scout_browser = require('../lib/scout_browser');
 var flatten_browser = require('../lib/flatten_browser');
+var zuul_reporter= require('zuul-reporter');
 
 program
 .version(require('../package.json').version)
@@ -35,6 +36,7 @@ program
 .option('--concurrency <n>', 'specify the number of concurrent browsers to test')
 .option('--no-coverage', 'disable code coverage analysis with istanbul')
 .option('--open', 'open a browser automatically. only used when --local is specified')
+.option('--report', 'write job statuses to zuul.json')
 .parse(process.argv);
 
 var config = {
@@ -310,7 +312,26 @@ scout_browser(function(err, all_browsers) {
             console.log('all browsers passed'.green);
         }
 
-        process.exit((passed_tests_count > 0 && failed_tests_count == 0) ? 0 : 1);
+        var code= (passed_tests_count > 0 && failed_tests_count == 0) ? 0 : 1;
+        if(program.report){
+            zuul_reporter(zuul._browsers,function(err,statuses){
+                var report= path.join(process.cwd(),'zuul.json');
+
+                if(err){
+                    code= 1;
+                    console.log('zuul-reporter error:',err.message.red);
+                }
+                else{
+                    fs.writeFileSync(report,JSON.stringify(statuses));
+                    console.log('wrote job statuses to zuul.json'.green);
+                }
+
+                process.exit(code);
+            });
+        }
+        else{
+            process.exit(code);
+        }
     });
 });
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "osenv": "0.0.3",
     "shallow-copy": "0.0.1",
     "shell-quote": "1.4.1",
+    "soysauce": "0.0.0-beta.1",
     "stack-mapper": "0.2.2",
     "stacktrace-js": "http://github.com/defunctzombie/stacktrace.js/tarball/07e7b9516f1449f5c209e4f67f11a43f738c1712",
     "superagent": "0.15.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zuul",
-  "version": "3.0.0",
+  "version": "3.0.0-beta.0",
   "description": "simple browser testing",
   "main": "lib/zuul.js",
   "dependencies": {
@@ -38,7 +38,8 @@
     "wd": "0.3.11",
     "xtend": "2.1.2",
     "yamljs": "0.1.4",
-    "zuul-localtunnel": "1.1.0"
+    "zuul-localtunnel": "1.1.0",
+    "zuul-reporter": "0.0.0-beta.0"
   },
   "devDependencies": {
     "after": "~0.8.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "xtend": "2.1.2",
     "yamljs": "0.1.4",
     "zuul-localtunnel": "1.1.0",
-    "zuul-reporter": "0.0.0-beta.0"
+    "zuul-reporter": "0.0.0"
   },
   "devDependencies": {
     "after": "~0.8.1",


### PR DESCRIPTION
Only one sticker per account by Currently it SauceLabs.
This patch, writes a summary of the build results to `zuul.json` by Using [Get Job API](https://docs.saucelabs.com/reference/rest-api/#get-job)

```bash
$ zuul --report -- test.js`
# ...
# all browsers passed
# wrote job statuses to zuul.json
```
zuul.json
```json
[
  {
    "browser_short_version": "7.1",
    "video_url": "https://saucelabs.com/jobs/9088430fbfa54694b369ab63ad482891/video.flv",
    "creation_time": 1431859507,
    "custom-data": null,
    "browser_version": "7.1.",
    "owner": "59798",
    "automation_backend": "appium",
    "id": "9088430fbfa54694b369ab63ad482891",
    "record_screenshots": true,
    "record_video": true,
    "build": null,
    "passed": false,
    "public": "public",
    "assigned_tunnel_id": null,
    "status": "complete",
    "log_url": "https://saucelabs.com/jobs/9088430fbfa54694b369ab63ad482891/selenium-server.log",
    "start_time": 1431859507,
    "proxied": false,
    "modification_time": 1431859582,
    "tags": [],
    "commands_not_successful": 3,
    "name": "zuul-example",
    "selenium_version": null,
    "manual": false,
    "end_time": 1431859582,
    "error": null,
    "os": "Mac 10.9",
    "breakpointed": null,
    "browser": "iphone"
  },
  {"many":"job statuses..."}
]
```

In the future, I think to create a sticker by using this json.
Like a coveralls.io. As a third party.