### PR TITLE
fix: use semverd appium-version

### DIFF
--- a/bin/zuul
+++ b/bin/zuul
@@ -300,6 +300,10 @@ scout_browser(function(err, all_browsers) {
     });
 
     zuul.run(function(passed) {
+        if (passed instanceof Error) {
+            throw passed;
+        }
+
         if (failed_tests_count > 0) {
             console.log('%d browser(s) failed'.red, failed_browsers_count);
         }

--- a/lib/SauceBrowser.js
+++ b/lib/SauceBrowser.js
@@ -60,7 +60,7 @@ SauceBrowser.prototype.start = function() {
             // appium-version is not always the latest stable,
             // we enforce it to be sure to always be up to date and fix the
             // saucelabs bugs
-            'appium-version': '1.3.6'
+            'appium-version': '1'
         }, conf.capabilities);
 
         // configures sauce connect with a tunnel identifier


### PR DESCRIPTION
with this parameter, as reviewed with a saucelabs developer
(https://github.com/defunctzombie/zuul/commit/358244c4c5f897f2d4f623d1136764d8440542b3#commitcomment-10112592), we will always be using the latest stable "appium" (mobile support of saucelabs) version

I also added a small annoying fix where you did not see the
require('tunnel-') error sometime because we did not check if an error
object was passed to end().