### PR TITLE
quiet the electron noise

### DIFF
--- a/lib/Electron.js
+++ b/lib/Electron.js
@@ -97,7 +97,7 @@ Electron.prototype.start = function() {
 
         cp.stderr.on('data', function (data) {
             if (/INFO:CONSOLE/.test(data)) return;
-            console.error('electron stderr: '.red + data);
+            debug('electron stderr: '.red + '%s', data);
         });
 
         cp.on('close', function (code) {


### PR DESCRIPTION
Electron is quite noisy so I switched the stderr messages from `console.error` to `debug`.  Btw, this feature is awesome, especially given how slow PhantomJS moves.