### PR TITLE
feat: gzip control app responses

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@
 * add `browser_retries` option (default to 6)
 * add `browser_output_timeout` option (default to no timeout)
 * properly shutdown all browsers when an uncaught exception is thrown on main `zuul` instance
+* gzip content from the control app (your bundle will now be gzipped)
 
 # 3.1.0 (2015-06-23)
 

--- a/lib/control-app.js
+++ b/lib/control-app.js
@@ -2,6 +2,7 @@ var path = require('path');
 var fs = require('fs');
 var deglob = require('globs-to-files');
 
+var compression = require('compression');
 var express = require('express');
 var expstate = require('express-state');
 var browserify = require('browserify');
@@ -45,6 +46,7 @@ module.exports = function(config) {
     build = require(config.builder)(files, config);
 
     var app = express();
+    app.use(compression());
 
     expstate.extend(app);
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "char-split": "0.2.0",
     "colors": "0.6.2",
     "commander": "2.1.0",
+    "compression": "1.5.0",
     "convert-source-map": "1.0.0",
     "debug": "2.1.0",
     "express": "3.4.8",


### PR DESCRIPTION
two reasons to do so:
  - your web application will always gzip responses, so tests serving
  gzip packages better mimic production system
  - cloud testing (from travis, from your local connection) can timeout
  because receiving 1mb+ of JS can take a very long time