### PR TITLE
Allow negative number for start of browser range

### DIFF
--- a/lib/flatten_browser.js
+++ b/lib/flatten_browser.js
@@ -118,15 +118,18 @@ function flatten(request, all_browsers) {
                     return item.version;
                 });
 
-                if (start !== 'oldest') {
-                    start_idx = v_map.indexOf(start);
-                }
-
                 if (end === 'latest') {
                     end_idx = get_numeric_versions(avail).length - 1;
                 }
                 else {
                     end_idx = v_map.lastIndexOf(end);
+                }
+
+                if (start.indexOf('-') !== -1) {
+                    start_idx = end_idx + Number(start);
+                }
+                else if (start !== 'oldest') {
+                    start_idx = v_map.indexOf(start);
                 }
 
                 if (start_idx < 0) {

--- a/lib/flatten_browser.js
+++ b/lib/flatten_browser.js
@@ -125,7 +125,7 @@ function flatten(request, all_browsers) {
                     end_idx = v_map.lastIndexOf(end);
                 }
 
-                if (start.indexOf('-') !== -1) {
+                if (start < 0) {
                     start_idx = end_idx + Number(start);
                 }
                 else if (start !== 'oldest') {

--- a/test/unit/flatten-browser.js
+++ b/test/unit/flatten-browser.js
@@ -53,7 +53,7 @@ test('flatten browser:stable', function(done) {
     done();
 });
 
-test('flatten broser:lastN', function(done) {
+test('flatten browser:negative', function(done) {
     var request = [
         {name: 'chrome', version: '-3..latest', platform: 'Windows 2012 R2'},
         {name: 'safari', version: '-1..latest'},
@@ -70,6 +70,29 @@ test('flatten broser:lastN', function(done) {
         {name: 'ipad', version: '7.1', platform: 'Mac 10.10'},
         {name: 'ipad', version: '8.0', platform: 'Mac 10.10'},
         {name: 'ipad', version: '8.1', platform: 'Mac 10.10'}
+    ];
+
+    assert.deepEqual(
+        flattenBrowser(request, allBrowsers),
+        expected,
+        'We found the browsers to test'
+    );
+
+    done();
+});
+
+test('flatten browser:oldest', function(done) {
+    var request = [
+        {name: 'chrome', version: 'oldest', platform: 'Windows 2012 R2'},
+        {name: 'firefox', version: 'oldest..4', platform: 'Windows 2012 R2'}
+    ];
+
+    var expected = [
+        {name: 'chrome', version: '26', platform: 'Windows 2012 R2'},
+        {name: 'firefox', version: '3.0', platform: 'Windows 2012 R2'},
+        {name: 'firefox', version: '3.5', platform: 'Windows 2012 R2'},
+        {name: 'firefox', version: '3.6', platform: 'Windows 2012 R2'},
+        {name: 'firefox', version: '4', platform: 'Windows 2012 R2'}
     ];
 
     assert.deepEqual(

--- a/test/unit/flatten-browser.js
+++ b/test/unit/flatten-browser.js
@@ -52,3 +52,31 @@ test('flatten browser:stable', function(done) {
 
     done();
 });
+
+test('flatten broser:lastN', function(done) {
+    var request = [
+        {name: 'chrome', version: '-3..latest', platform: 'Windows 2012 R2'},
+        {name: 'safari', version: '-1..latest'},
+        {name: 'ipad', version: '-2..8.1', platform: 'Mac 10.10'}
+    ];
+
+    var expected = [
+        {name: 'chrome', version: '39', platform: 'Windows 2012 R2'},
+        {name: 'chrome', version: '40', platform: 'Windows 2012 R2'},
+        {name: 'chrome', version: '41', platform: 'Windows 2012 R2'},
+        {name: 'chrome', version: '42', platform: 'Windows 2012 R2'},
+        {name: 'safari', version: '7', platform: 'Mac 10.9'},
+        {name: 'safari', version: '8', platform: 'Mac 10.10'},
+        {name: 'ipad', version: '7.1', platform: 'Mac 10.10'},
+        {name: 'ipad', version: '8.0', platform: 'Mac 10.10'},
+        {name: 'ipad', version: '8.1', platform: 'Mac 10.10'}
+    ];
+
+    assert.deepEqual(
+        flattenBrowser(request, allBrowsers),
+        expected,
+        'We found the browsers to test'
+    );
+
+    done();
+});


### PR DESCRIPTION
I'd been wanting a solution to #209 for a little while, and finally had some free time to code it up. It didn't seem like a syntax had been settled on in the issue discussion, so I went with what I'd been thinking about.

This PR allows you to specify a negative number for the start of a browser range. So, for example, if the latest version of a browser is 42, the string `-3..latest` will yield the range 39, 40, 41, and 42 inclusive. This will also work with manually specified versions, like `-2..8.1` for iPhone.

I'm getting a Sauce authentication error when I try to run the full test suite, for some weird reason (my Open Sauce account has been having some issues recently, so it might just be that). That being said, it's a relatively minor tweak to flatten_browser, so I don't expect anything else to break. I added a 'oldest' test to the flatten-browser unit test to try to make sure.