### PR TITLE
fix: lower output by stacking browser names

### DIFF
--- a/bin/zuul
+++ b/bin/zuul
@@ -239,6 +239,7 @@ scout_browser(function(err, all_browsers) {
     var passed_tests_count = 0;
     var failed_tests_count = 0;
     var failed_browsers_count = 0;
+    var lastOutputName;
 
     zuul.on('browser', function(browser) {
         browsers.push(browser);
@@ -264,7 +265,11 @@ scout_browser(function(err, all_browsers) {
             });
 
             reporter.on('console', function(msg) {
-                console.log('%s console'.white, name);
+                if (lastOutputName !== name) {
+                    lastOutputName = name;
+                    console.log('%s console'.white, name);
+                }
+
                 console.log.apply(console, msg.args);
             });
 


### PR DESCRIPTION
From:
```
<firefox 40 on Windows 10> console
<firefox 40 on Windows 10> console
ok 14 should be equal
<firefox 40 on Windows 10> console
ok 15 We received a result event
```

To:
```
<firefox 40 on Windows 10> console
ok 14 should be equal
ok 15 We received a result event
<chrome 40 on ..>
````

=> We only display the browsername if it changed since last output.

This might be an issue because I guess on very long test output when looking at the travis log output it might be harder to find what was the browser (you have to scroll up until you get the name).

But since when a browser error we already output the browser name, we should be good.

Help fighting the 4mb limit of travis:
travis-ci/travis-ci#1382