### PR TITLE
Replace bouncy with http-proxy

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -1,4 +1,5 @@
-var bouncy = require('bouncy');
+var http = require('http');
+var httpProxy = require('http-proxy');
 var debug = require('debug')('zuul:setup');
 
 var user_server = require('./user-server');
@@ -53,19 +54,38 @@ function setup_test_instance(opt, cb) {
             bouncer_port = config.phantom;
         }
 
-        bouncer = bouncy(function (req, res, bounce) {
-            var url = req.url.split('?')[0];
-            if (!support_port || url.split('/')[1] === '__zuul') {
-                bounce(control_port, { headers: { connection: 'close' }});
-                return;
-            }
+        var proxy = httpProxy.createProxy();
+        proxy.on('proxyReq', on_proxy_req);
 
-            var opts = {};
-            if (req.headers.connection && req.headers.connection.toLowerCase().indexOf('upgrade') === -1) {
-                opts.headers = { connection: 'close' };
+        bouncer = http.createServer();
+        bouncer.on('request', on_request(proxy.web));
+        bouncer.on('upgrade', on_request(proxy.ws));
+
+        function on_request(bounce) {
+            return function(req, res) {
+                var args = [].slice.call(arguments);
+                if (is_control_req(req)) {
+                    args.push({ target: 'http://localhost:' + control_port });
+                    bounce.apply(proxy, args);
+                    return;
+                }
+
+                args.push({ target: 'http://localhost:' + support_port });
+                bounce.apply(proxy, args);
+            };
+        }
+
+        function on_proxy_req(proxyReq, req, res, options) {
+            if (is_control_req(req) ||
+                (req.headers.connection && req.headers.connection.toLowerCase().indexOf('upgrade') === -1)) {
+                proxyReq.setHeader('connection', 'close');
             }
-            bounce(support_port, opts);
-        });
+        }
+
+        function is_control_req(req) {
+            var url = req.url.split('?')[0];
+            return !support_port || url.split('/')[1] === '__zuul';
+        }
 
         bouncer.listen(bouncer_port, bouncer_active);
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "dependencies": {
     "JSON2": "0.1.0",
     "batch": "0.5.0",
-    "bouncy": "3.2.2",
     "browserify": "11.1.0",
     "browserify-istanbul": "0.1.5",
     "char-split": "0.2.0",
@@ -22,6 +21,7 @@
     "globs-to-files": "1.0.0",
     "hbs": "2.4.0",
     "highlight.js": "7.5.0",
+    "http-proxy": "1.11.2",
     "humanize-duration": "2.4.0",
     "istanbul-middleware": "0.2.0",
     "load-script": "0.0.5",


### PR DESCRIPTION
There is a bug of websocket on bouncy module (https://github.com/substack/bouncy/issues/69), and the module hasn't been maintained recently. I think it would be nice to use http-proxy instead.
As far as I tested, this PR can handle websocket properly.