### PR TITLE
package: update istanbul-middleware to 0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "hbs": "2.4.0",
     "highlight.js": "7.5.0",
     "humanize-duration": "2.4.0",
-    "istanbul-middleware": "0.2.0",
+    "istanbul-middleware": "0.2.1",
     "load-script": "0.0.5",
     "lodash": "2.4.1",
     "opener": "1.4.0",


### PR DESCRIPTION
This silences a deprecation warning and fixes some security vulnerabilites.
See https://github.com/gotwarlost/istanbul-middleware/pull/20.