### PR TITLE
Temporary fix for current_test issue (#249)

### DIFF
--- a/bin/zuul
+++ b/bin/zuul
@@ -281,7 +281,7 @@ scout_browser(function(err, all_browsers) {
 
             reporter.on('assertion', function(assertion) {
                 console.log();
-                console.log('%s %s'.red, name, current_test.name);
+                console.log('%s %s'.red, name, current_test ? current_test.name : 'undefined test');
                 console.log('Error: %s'.red, assertion.message);
 
                 //When testing with microsoft edge:


### PR DESCRIPTION
The main problem with #249, that it stops the whole execution, and it's not possible to figure out which test or browser have an error.

This temporary fix helped me to figure out the problem:

```
<iphone 7.1 on Mac 10.10> undefined test
Error: SecurityError: DOM Exception 18: An attempt was made to break through the security policy of the user agent. (https://evidqmsasw.localtunnel.me/__zuul/test-bundle.js:10638)

- failed: <iphone 7.1 on Mac 10.10> (0 failed, 0 passed)
```