### PR TITLE
feat: easier phantomjs debugging

### DIFF
--- a/bin/zuul
+++ b/bin/zuul
@@ -22,6 +22,8 @@ program
 .option('--tunnel [type]', 'establish a tunnel for outside access. only used when --local is specified')
 .option('--disable-tunnel', 'don\'t establish a tunnel for outside access. override any config in .zuul.yml and .zuulrc')
 .option('--phantom [port]', 'run tests in phantomjs. PhantomJS must be installed separately.')
+.option('--phantom-remote-debugger-port [port]', 'connect phantom to remote debugger')
+.option('--phantom-remote-debugger-autorun', 'run tests automatically when --phantom-remote-debugger-port is specified')
 .option('--electron', 'run tests in electron. electron must be installed separately.')
 .option('--tunnel-host <host url>', 'specify a localtunnel server to use for forwarding')
 .option('--sauce-connect [tunnel-identifier]', 'use saucelabs with sauce connect instead of localtunnel. Optionally specify the tunnel-identifier')
@@ -43,6 +45,8 @@ var config = {
     ui: program.ui,
     tunnel: program.tunnel,
     phantom: program.phantom,
+    phantomRemoteDebuggerPort: program.phantomRemoteDebuggerPort,
+    phantomRemoteDebuggerAutorun: program.phantomRemoteDebuggerAutorun,
     electron: program.electron,
     prj_dir: process.cwd(),
     tunnel_host: program.tunnelHost,

--- a/lib/PhantomBrowser.js
+++ b/lib/PhantomBrowser.js
@@ -73,8 +73,12 @@ PhantomBrowser.prototype.start = function() {
         self.emit('init', url);
         self.emit('start', reporter);
 
-        var args = [path.join(__dirname, 'phantom-run.js'), url];
+        var debugArgs = [
+            self._opt.phantomRemoteDebuggerPort ? '--remote-debugger-port=' + self._opt.phantomRemoteDebuggerPort : '',
+            self._opt.phantomRemoteDebuggerAutorun ? '--remote-debugger-autorun=true' : ''
+        ].filter(Boolean);
 
+        var args = debugArgs.concat([path.join(__dirname, 'phantom-run.js'), url]);
         var cp = spawn(binpath, args);
 
         var split = Split();
@@ -88,7 +92,12 @@ PhantomBrowser.prototype.start = function() {
             }
 
             debug('msg: %j', msg);
-            reporter.emit(msg.type, msg);
+
+            if (msg.type === 'exception') {
+                self.emit('error', new Error(msg.message));
+            } else {
+                reporter.emit(msg.type, msg);
+            }
         });
 
         cp.stdout.setEncoding('utf8');

--- a/lib/phantom-run.js
+++ b/lib/phantom-run.js
@@ -5,19 +5,41 @@ var page = require('webpage').create();
 var system = require('system');
 
 var url = system.args[1];
+var systemMessages = [];
 
-page.onError = function(msg) {
-    console.error(JSON.stringify(msg));
+phantom.onError = function(msg, trace) {
+    systemMessages.push({
+        type: 'exception',
+        message: msg,
+        trace: trace
+    });
+};
+
+page.onError = function(msg, trace) {
+    systemMessages.push({
+        type: 'exception',
+        message: msg,
+        trace: trace
+    });
 };
 
 page.open(url, function(status) {
     var msg_tid = setInterval(function() {
         var msgs = page.evaluate(function() {
-            return window.zuul_msg_bus.splice(0, window.zuul_msg_bus.length);
-        });
+            return window.zuul_msg_bus && window.zuul_msg_bus.splice(0, window.zuul_msg_bus.length);
+        }) || [];
 
-        msgs.forEach(function(msg) {
+        var messages = msgs.concat(systemMessages.splice(0, systemMessages.length));
+
+        messages.forEach(function(msg) {
             console.log(JSON.stringify(msg));
+            if (msg.type === 'exception') {
+                console.error(msg.message);
+                console.trace(msg.trace);
+                return setTimeout(function() {
+                    phantom.exit(1);
+                });
+            }
             if (msg.type === 'done') {
                 return setTimeout(function() {
                   phantom.exit(msg.passed ? 0 : 1);


### PR DESCRIPTION
This PR aims at making phantomjs debugging easier:

* add `--phantom-remote-debugger-port=[port]` which maps to phantoms `--remote-debugger-port=[port]`
* add `--phantom-remote-debugger-autorun` which maps to phantoms `--remote-debugger-autorun`
* add `phantom.onError` handler
* process messages from `phantom.onError`, `page.onError` as `exceptions`, exit the phantom run with `1` if an exception occurs