### PR TITLE
package: update phantomjs to 1.9.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "browzers": "1.2.0",
     "bulk-require": "0.2.1",
     "mocha": "~1.16.2",
-    "phantomjs": "1.9.12",
+    "phantomjs": "1.9.19",
     "tape": "3.5.0",
     "through2": "0.6.3"
   },


### PR DESCRIPTION
I'm not sure why, but when running `npm install` the installation process gets stuck with the current version of phantomjs. Everything works fine with the latest version.