### PR TITLE
use browserify 13

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "JSON2": "0.1.0",
     "batch": "0.5.0",
-    "browserify": "11.1.0",
+    "browserify": "13.0.0",
     "browserify-istanbul": "0.1.5",
     "char-split": "0.2.0",
     "colors": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "superagent": "0.15.7",
     "tap-finished": "0.0.1",
     "tap-parser": "0.7.0",
-    "watchify": "3.4.0",
+    "watchify": "3.7.0",
     "wd": "0.3.11",
     "xtend": "2.1.2",
     "yamljs": "0.1.4",


### PR DESCRIPTION
Browserify 13 has speed improvements to the buffer module of up to 30%.

Browserify 12 switched exclusively to streams3 across the whole dependency tree, so it's quicker (fewer KBs) to install, and it's streams3 which adds features for some use cases.

Changelog: https://github.com/substack/node-browserify/blob/master/changelog.markdown