### PR TITLE
Use phantomjs-prebuilt instead of phantomjs

### DIFF
--- a/lib/PhantomBrowser.js
+++ b/lib/PhantomBrowser.js
@@ -25,7 +25,7 @@ PhantomBrowser.prototype.__proto__ = EventEmitter.prototype;
 PhantomBrowser.prototype.start = function() {
     var self = this;
 
-    var phantomjs = require('phantomjs');
+    var phantomjs = require('phantomjs-prebuilt');
     var binpath = phantomjs.path;
 
     self.controller = setup_test_instance(self._opt, function(err, url) {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "browzers": "1.2.0",
     "bulk-require": "0.2.1",
     "mocha": "~1.16.2",
-    "phantomjs": "1.9.19",
+    "phantomjs-prebuilt": "2.1.4",
     "tape": "3.5.0",
     "through2": "0.6.3"
   },


### PR DESCRIPTION
The name was changed at the request of PhantomJS team.

https://github.com/Medium/phantomjs/issues/447#ref-commit-dbf4a91