### PR TITLE
saucebrowser: use appium 1.5.x

### DIFF
--- a/lib/SauceBrowser.js
+++ b/lib/SauceBrowser.js
@@ -64,7 +64,7 @@ SauceBrowser.prototype.start = function() {
             // appium-version is not always the latest stable,
             // we enforce it to be sure to always be up to date and fix the
             // saucelabs bugs
-            'appium-version': '1.4'
+            'appium-version': '1.5'
         }, conf.capabilities);
 
         // configures sauce connect with a tunnel identifier


### PR DESCRIPTION
Appium [1.5.2](https://github.com/appium/appium/releases/tag/v1.5.2) is now available on Sauce Labs.