### PR TITLE
Bump browserify-istanbul

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "JSON2": "0.1.0",
     "batch": "0.5.0",
     "browserify": "13.0.0",
-    "browserify-istanbul": "0.1.5",
+    "browserify-istanbul": "^2.0.0",
     "char-split": "0.2.0",
     "colors": "0.6.2",
     "commander": "2.1.0",


### PR DESCRIPTION
Old version disallowed most ES6 syntax, namely template strings.