### PR TITLE
timeout fix for electron >= v1.2.0

### DIFF
--- a/lib/electron-inject.js
+++ b/lib/electron-inject.js
@@ -2,7 +2,7 @@
     var ipc = require('ipc');
     window.zuul_msg_bus = [];
     ipc.on('started', loop);
-    ipc.send('started');
+    window.setTimeout(ipc.send.bind(ipc, 'started'));
     function loop() {
         var msgs = window.zuul_msg_bus.splice(0, window.zuul_msg_bus.length);
         msgs.forEach(send);


### PR DESCRIPTION
It seems without this timeout fix, tests hang when `electron v1.2.0` or higher is installed.