### PR TITLE
saucebrowser: use an environment variable to specify the appium version

### DIFF
--- a/lib/SauceBrowser.js
+++ b/lib/SauceBrowser.js
@@ -60,12 +60,15 @@ SauceBrowser.prototype.start = function() {
             tags: conf.tags || [],
             browserName: conf.browser,
             version: conf.version,
-            platform: conf.platform,
-            // appium-version is not always the latest stable,
-            // we enforce it to be sure to always be up to date and fix the
-            // saucelabs bugs
-            'appium-version': '1.5'
+            platform: conf.platform
         }, conf.capabilities);
+
+        // use the SAUCE_APPIUM_VERSION environment variable to specify the
+        // Appium version. If not specified the test will run against the
+        // default Appium version
+        if (process.env.SAUCE_APPIUM_VERSION) {
+            init_conf['appium-version'] = process.env.SAUCE_APPIUM_VERSION;
+        }
 
         // configures sauce connect with a tunnel identifier
         // if sauce_connect is true, use the TRAVIS_JOB_NUMBER environment variable


### PR DESCRIPTION
Appium 1.5 does not work on OS X 10.9:
```
/Users/luigi/repos/eventemitter3/node_modules/zuul/bin/zuul:328
            throw err.message;
            ^
iphone@7.0: [init({"name":"eventemitter3","tags":[],"browserName":"iphone","version":"7.0","platform":"Mac 10.9","appium-version":"1.5","record-screenshots":false,"record-video":false})] The environment you requested was unavailable.: Appium 1.5.3 does not support Mac 10.9. Please check our platform configurator (https://saucelabs.com/docs/platforms)
```
This patch fixes the issue by not enforcing a specific Appium version.