### PR TITLE
Handle proxy errors

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -56,7 +56,13 @@ function setup_test_instance(opt, cb) {
 
         var proxy = httpProxy.createProxy();
         proxy.on('proxyReq', on_proxy_req);
+        proxy.on('error', function (err, req, res) {
+          if (!res.headersSent) {
+            res.writeHead(500, { 'content-type': 'application/json' });
+          }
 
+          res.end(JSON.stringify({ err: err.message }));
+        })
         bouncer = http.createServer();
         bouncer.on('request', on_request(proxy.web));
         bouncer.on('upgrade', on_request(proxy.ws));


### PR DESCRIPTION
Fixes #264
- This is based directly on [Feross's code here](https://github.com/feross/webtorrent-www/commit/cd4cb63575d26457543ac27a6ca01b85342ea715)
- Testing against one of my projects, current zuul master consistently fails with `Error: socket hang up`
- With this change, it consistently passes without issue. However, I have not run the full zuul test suite as I don't know exactly how to do that (although it seems like I have them queued to run via saucelabs, but they've been queued for ~15 minutes now). So if maintainers want to make sure all the zuul tests still pass on this branch before merging, that would be great.
