### PR TITLE
Support new 'electron' package (electron-prebuilt is deprecated)

### DIFF
--- a/lib/Electron.js
+++ b/lib/Electron.js
@@ -25,7 +25,12 @@ Electron.prototype.__proto__ = EventEmitter.prototype;
 Electron.prototype.start = function() {
     var self = this;
 
-    var binpath = require('electron-prebuilt');
+    var binpath;
+    try {
+        binpath = require('electron-prebuilt');
+    } catch (err) {
+        binpath = require('electron');
+    }
 
     self.controller = setup_test_instance(self._opt, function(err, url) {
         if (err) {


### PR DESCRIPTION
The Electron team is now publishing electron at electron instead of
electron-prebuilt.

Fixes #305.