### PR TITLE
Bumped yamljs dependency to v0.2.8.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "watchify": "3.7.0",
     "wd": "0.3.11",
     "xtend": "2.1.2",
-    "yamljs": "0.1.4",
+    "yamljs": "0.2.8",
     "zuul-localtunnel": "1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This is to get rid to on of the minimatch warnings.