### PR TITLE
feat: Added --no-instrument option.

### DIFF
--- a/bin/zuul
+++ b/bin/zuul
@@ -36,6 +36,7 @@ program
 .option('--browser-output-timeout <timeout>', 'how much time to wait between two test results, default to -1 (no timeout)')
 .option('--concurrency <n>', 'specify the number of concurrent browsers to test')
 .option('--no-coverage', 'disable code coverage analysis with istanbul')
+.option('--no-instrument', 'disable code coverage instrumentation with istanbul')
 .option('--open', 'open a browser automatically. only used when --local is specified')
 .parse(process.argv);
 
@@ -54,6 +55,7 @@ var config = {
     server: program.server,
     concurrency: program.concurrency,
     coverage: program.coverage,
+    instrument: program.instrument,
     open: program.open,
     browser_retries: program.browserRetries && parseInt(program.browserRetries, 10),
     browser_output_timeout: program.browserOutputTimeout && parseInt(program.browserOutputTimeout, 10),

--- a/lib/builder-browserify.js
+++ b/lib/builder-browserify.js
@@ -97,7 +97,7 @@ function initBundler(files, config) {
     debug('configuring browserify with provided options: %j', config.browserify);
     configure(bundler, config.browserify);
 
-    if (config.coverage && config.local) {
+    if (config.coverage && config.instrument && config.local) {
         debug('using istanbul transform');
         bundler.transform(istanbul({
             defaultIgnore: true


### PR DESCRIPTION
This PR implements a `--no-instrument` configuration flag. This is useful when coverage is desired, but instrumentation happens at a different point in the pipeline; such as using `babel-plugin-istanbul`. This is [how `nyc` solves the same issue](https://github.com/istanbuljs/nyc#use-with-babel-plugin-istanbul-for-es6es7es2015-support).

Example use case: https://github.com/shannonmoeller/babel-browserify-nyc-tape-zuul-isomorphic-demo