### PR TITLE
Stop using http tarball for stacktrace-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "shallow-copy": "0.0.1",
     "shell-quote": "1.4.1",
     "stack-mapper": "0.2.2",
-    "stacktrace-js": "http://github.com/defunctzombie/stacktrace.js/tarball/07e7b9516f1449f5c209e4f67f11a43f738c1712",
+    "stacktrace-js": "1.3.1",
     "superagent": "0.15.7",
     "tap-finished": "0.0.1",
     "tap-parser": "0.7.0",


### PR DESCRIPTION
@defunctzombie I cannot recall why we where linking to your own stacktrace version, what did it fixed that is not fixed inside the original module?

The thing is that right now with yarn I have issues installing zuul, haven't dig into it. I am just almost sure this will solve it.