### PR TITLE
Support custom loopback hostname

### DIFF
--- a/bin/zuul
+++ b/bin/zuul
@@ -27,6 +27,7 @@ program
 .option('--electron', 'run tests in electron. electron must be installed separately.')
 .option('--tunnel-host <host url>', 'specify a localtunnel server to use for forwarding')
 .option('--sauce-connect [tunnel-identifier]', 'use saucelabs with sauce connect instead of localtunnel. Optionally specify the tunnel-identifier')
+.option('--loopback <host name>', 'hostname to use instead of localhost, to accomodate Safari and Edge with Sauce Connect. Must resolve to 127.0.0.1')
 .option('--server <the server script>', 'specify a server script to be run')
 .option('--list-available-browsers', 'list available browsers and versions')
 .option('--browser-name <browser name>', 'specficy the browser name to test an individual browser')
@@ -52,6 +53,7 @@ var config = {
     prj_dir: process.cwd(),
     tunnel_host: program.tunnelHost,
     sauce_connect: program.sauceConnect,
+    loopback: program.loopback,
     server: program.server,
     concurrency: program.concurrency,
     coverage: program.coverage,

--- a/lib/SauceBrowser.js
+++ b/lib/SauceBrowser.js
@@ -52,7 +52,7 @@ SauceBrowser.prototype.start = function() {
             return self.shutdown(err);
         }
 
-        self.emit('init', conf);
+        self.emit('init', conf, url);
 
         var init_conf = xtend({
             build: conf.build,

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -35,6 +35,7 @@ function setup_test_instance(opt, cb) {
     function setup(_support_server) {
         support_server = _support_server;
         var config = opt;
+        var loopback = config.loopback || 'localhost';
         var control_port = opt.control_port;
 
         var support_port = undefined;
@@ -65,12 +66,12 @@ function setup_test_instance(opt, cb) {
             return function(req, res) {
                 var args = [].slice.call(arguments);
                 if (is_control_req(req)) {
-                    args.push({ target: 'http://localhost:' + control_port });
+                    args.push({ target: 'http://' + loopback + ':' + control_port });
                     bounce.apply(proxy, args);
                     return;
                 }
 
-                args.push({ target: 'http://localhost:' + support_port }, on_support_server_proxy_done);
+                args.push({ target: 'http://' + loopback + ':' + support_port }, on_support_server_proxy_done);
                 bounce.apply(proxy, args);
             };
         }
@@ -100,7 +101,7 @@ function setup_test_instance(opt, cb) {
             debug('bouncer active on port %d', app_port);
 
             if (!config.tunnel) {
-                return cb(null, 'http://localhost:' + app_port + '/__zuul');
+                return cb(null, 'http://' + loopback + ':' + app_port + '/__zuul');
             }
 
             tunnel.connect(app_port, cb);

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -12,18 +12,22 @@ function setup_test_instance(opt, cb) {
     var support_server = undefined;
     var bouncer = undefined;
     var Tunnel;
+    var tunnel;
+
     if (typeof opt.tunnel === 'string') {
         Tunnel = require('zuul-' + opt.tunnel);
         debug('using zuul-%s to tunnel', opt.tunnel);
     } else if (typeof opt.tunnel === 'object' && opt.tunnel.type) {
         Tunnel = require('zuul-' + opt.tunnel.type);
         debug('using zuul-%s to tunnel', opt.tunnel.type);
-    } else {
+    } else if (opt.tunnel !== false) {
         Tunnel = require('zuul-localtunnel');
         debug('using zuul-localhost to tunnel');
     }
 
-    var tunnel = new Tunnel(opt);
+    if (Tunnel) {
+        tunnel = new Tunnel(opt);
+    }
 
     if (opt.server) {
         user_server(opt.server, setup);
@@ -100,7 +104,7 @@ function setup_test_instance(opt, cb) {
             var app_port = bouncer.address().port;
             debug('bouncer active on port %d', app_port);
 
-            if (!config.tunnel) {
+            if (!tunnel) {
                 return cb(null, 'http://' + loopback + ':' + app_port + '/__zuul');
             }
 
@@ -110,7 +114,10 @@ function setup_test_instance(opt, cb) {
 
     function shutdown() {
         bouncer.close();
-        tunnel.close();
+
+        if (tunnel) {
+            tunnel.close();
+        }
 
         if (support_server) {
             support_server.process.kill('SIGKILL');

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -66,16 +66,21 @@ function setup_test_instance(opt, cb) {
         bouncer.on('request', on_request(proxy.web));
         bouncer.on('upgrade', on_request(proxy.ws));
 
+        function local_url (port, path) {
+            var base = 'http://' + loopback + ':' + port;
+            return path ? base + path : base;
+        }
+
         function on_request(bounce) {
             return function(req, res) {
                 var args = [].slice.call(arguments);
                 if (is_control_req(req)) {
-                    args.push({ target: 'http://' + loopback + ':' + control_port });
+                    args.push({ target: local_url(control_port) });
                     bounce.apply(proxy, args);
                     return;
                 }
 
-                args.push({ target: 'http://' + loopback + ':' + support_port }, on_support_server_proxy_done);
+                args.push({ target: local_url(support_port) }, on_support_server_proxy_done);
                 bounce.apply(proxy, args);
             };
         }
@@ -105,7 +110,7 @@ function setup_test_instance(opt, cb) {
             debug('bouncer active on port %d', app_port);
 
             if (!tunnel) {
-                return cb(null, 'http://' + loopback + ':' + app_port + '/__zuul');
+                return cb(null, local_url(app_port, '/__zuul'));
             }
 
             tunnel.connect(app_port, cb);

--- a/test/integration/sauce-connect-loopback.js
+++ b/test/integration/sauce-connect-loopback.js
@@ -1,0 +1,74 @@
+var Zuul = require('../../');
+
+var auth = require('../auth');
+var assert = require('assert');
+var URL = require('url');
+
+test('sauce connect without loopback option', function(done) {
+    var config = {
+        ui: 'mocha-bdd',
+        sauce_connect: true,
+        username: auth.username,
+        key: auth.key
+    };
+
+    var zuul = Zuul(config);
+
+    zuul.browser({
+        name: 'internet explorer',
+        version: '11'
+    });
+
+    var browser = zuul._browsers[0];
+
+    browser.on('init', function(browserConfig, url) {
+        assert.equal(zuul._config.sauce_connect, true)
+        assert.equal(zuul._config.tunnel, false)
+        assert.equal(URL.parse(url).hostname, 'localhost')
+
+        browser.shutdown();
+    });
+
+    browser.on('done', function(/*stats*/) {
+        done();
+    });
+
+    browser.on('error', done);
+
+    browser.start();
+});
+
+test('sauce connect with loopback option', function(done) {
+    var config = {
+        ui: 'mocha-bdd',
+        sauce_connect: true,
+        loopback: 'test.local',
+        username: auth.username,
+        key: auth.key
+    };
+
+    var zuul = Zuul(config);
+
+    zuul.browser({
+        name: 'internet explorer',
+        version: '11'
+    });
+
+    var browser = zuul._browsers[0];
+
+    browser.on('init', function(browserConfig, url) {
+        assert.equal(zuul._config.sauce_connect, true)
+        assert.equal(zuul._config.tunnel, false)
+        assert.equal(URL.parse(url).hostname, 'test.local')
+
+        browser.shutdown();
+    });
+
+    browser.on('done', function(/*stats*/) {
+        done();
+    });
+
+    browser.on('error', done);
+
+    browser.start();
+});


### PR DESCRIPTION
When using Sauce Connect, Safari and Edge [require a workaround](https://support.saucelabs.com/hc/en-us/articles/115002212447-Unable-to-Reach-Application-on-localhost-for-Tests-Run-on-Safari-8-and-9-and-Edge):

> The issue is these browsers will never send localhost URLs via a proxy [..]. You have two options for a workaround. 
> 
> 1. Modify the hosts file in the machine running Sauce Connect Proxy. Just add a fake domain, such as `myname.local`, that points to `127.0.0.1`. Then, point your tests to that URL instead of `localhost`. This will skip the localhost proxy entirely and prevent the issue, and may even improve the performance of your tests. 
 > 
> 2. Use the Sauce Connect localhost proxy to connect over a different port. [..]

I opted for the first. This PR adds a `--loopback <hostname>` option to zuul. For example, `zuul --loopback test.local` will open `http://test.local:<port>/__zuul` instead of `http://localhost:<port>/__zuul`.

Usage can be seen [in memdown](https://github.com/Level/memdown/commit/c05bff0d52c87f780555827ff77e5573c2bb0e6a).